### PR TITLE
630:P1 Add unit tests for OpenAPI aggregation and formatting helpers

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -85,6 +85,7 @@
     "zen-observable": "^0.10.0"
   },
   "devDependencies": {
+    "@backstage/e2e-test-utils": "workspace:^",
     "@backstage/test-utils": "workspace:^",
     "@playwright/test": "^1.32.3",
     "@testing-library/dom": "^10.0.0",

--- a/plugins/catalog-backend-module-backstage-openapi/src/InternalOpenApiDocumentationProvider.test.ts
+++ b/plugins/catalog-backend-module-backstage-openapi/src/InternalOpenApiDocumentationProvider.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  OpenAPIObject,
+  OperationObject,
+  PathItemObject,
+} from 'openapi3-ts';
+import yaml from 'yaml';
+import {
+  formatDefinition,
+  mergeSpecs,
+} from './InternalOpenApiDocumentationProvider';
+
+describe('InternalOpenApiDocumentationProvider helpers', () => {
+  describe('mergeSpecs', () => {
+    it('merges multiple plugin specs into a single OpenAPI document with base server', async () => {
+      const baseUrl = 'https://backstage.example.com';
+
+      const specA: OpenAPIObject = {
+        openapi: '3.0.0',
+        info: { title: 'Service A', version: '1.0.0' },
+        paths: {
+          '/service-a': {
+            get: {
+              operationId: 'getServiceA',
+            } as OperationObject,
+          } as PathItemObject,
+        },
+      };
+
+      const specB: OpenAPIObject = {
+        openapi: '3.0.0',
+        info: { title: 'Service B', version: '1.0.0' },
+        paths: {
+          '/service-b': {
+            post: {
+              operationId: 'createServiceB',
+            } as OperationObject,
+          } as PathItemObject,
+        },
+      };
+
+      const merged = await mergeSpecs({ baseUrl, specs: [specA, specB] });
+
+      expect(merged.openapi).toBe('3.0.3');
+      expect(merged.info?.title).toBe('Backstage API');
+      expect(merged.info?.version).toBe('1');
+
+      expect(merged.servers?.[0]?.url).toBe(baseUrl);
+
+      expect(Object.keys(merged.paths ?? {})).toEqual(
+        expect.arrayContaining(['/service-a', '/service-b']),
+      );
+      expect(
+        (merged.paths?.['/service-a']?.get as OperationObject)?.operationId,
+      ).toBe('getServiceA');
+      expect(
+        (merged.paths?.['/service-b']?.post as OperationObject)?.operationId,
+      ).toBe('createServiceB');
+    });
+  });
+
+  describe('formatDefinition', () => {
+    const definition: OpenAPIObject = {
+      openapi: '3.0.3',
+      info: {
+        title: 'Backstage API',
+        version: '1.0.0',
+      },
+      paths: {},
+    };
+
+    it('formats definition as pretty-printed JSON', () => {
+      const result = formatDefinition(definition, 'json');
+      expect(typeof result).toBe('string');
+
+      const parsed = JSON.parse(result);
+      expect(parsed).toEqual(definition);
+    });
+
+    it('formats definition as YAML', () => {
+      const result = formatDefinition(definition, 'yaml');
+      expect(typeof result).toBe('string');
+
+      const parsed = yaml.parse(result);
+      expect(parsed).toEqual(definition);
+    });
+
+    it('throws for unsupported format', () => {
+      expect(() => formatDefinition(definition, 'xml')).toThrow(
+        'Unsupported format type: xml',
+      );
+    });
+  });
+});

--- a/plugins/catalog-backend-module-backstage-openapi/src/InternalOpenApiDocumentationProvider.ts
+++ b/plugins/catalog-backend-module-backstage-openapi/src/InternalOpenApiDocumentationProvider.ts
@@ -69,7 +69,7 @@ const addTagsToSpec = (spec: OpenAPIObject, tag: string) => {
   });
 };
 
-const mergeSpecs = async ({
+export const mergeSpecs = async ({
   baseUrl,
   specs,
 }: {
@@ -155,7 +155,7 @@ const loadSpecs = async ({
   return mergeSpecs({ baseUrl, specs });
 };
 
-const formatDefinition = (
+export const formatDefinition = (
   definition: any,
   format: string | 'json' | 'yaml',
 ) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3777,7 +3777,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/e2e-test-utils@workspace:*, @backstage/e2e-test-utils@workspace:packages/e2e-test-utils":
+"@backstage/e2e-test-utils@workspace:*, @backstage/e2e-test-utils@workspace:^, @backstage/e2e-test-utils@workspace:packages/e2e-test-utils":
   version: 0.0.0-use.local
   resolution: "@backstage/e2e-test-utils@workspace:packages/e2e-test-utils"
   dependencies:
@@ -30726,6 +30726,7 @@ __metadata:
     "@backstage/core-app-api": "workspace:^"
     "@backstage/core-components": "workspace:^"
     "@backstage/core-plugin-api": "workspace:^"
+    "@backstage/e2e-test-utils": "workspace:^"
     "@backstage/frontend-app-api": "workspace:^"
     "@backstage/integration-react": "workspace:^"
     "@backstage/plugin-api-docs": "workspace:^"


### PR DESCRIPTION
Closes #6

### Summary

- Add `InternalOpenApiDocumentationProvider.test.ts` under `plugins/catalog-backend-module-backstage-openapi`.
- Exercise the OpenAPI aggregation helpers (`mergeSpecs`) with multiple sample service specs to validate the merged output.
- Exercise the formatting helper (`formatDefinition`) to ensure generated OpenAPI definitions serialize correctly to JSON and YAML and fail fast on unsupported formats.

### How to run the relevant tests

cd backstage
yarn test plugins/catalog-backend-module-backstage-openapi


### What changed and why?

- Added focused unit tests that build small sample OpenAPI documents (standing in for generated Protobuf/protoc-gen-doc output) and pass them through the aggregation and formatting logic.
- This protects the internal OpenAPI "generation" pipeline from regressions: if merging logic or formatting changes, we now have concrete expectations on the resulting OpenAPI structure.
- The tests assert that the merged spec preserves key fields (version, title, base server URL) and includes the expected paths and operations from each input spec.

### Why is this the right test layer (Unit)?

- The transformation from individual service descriptions (e.g., generated from Protobuf) into a single OpenAPI document is a pure-function-style operation that's cheap and reliable to validate at the unit-test level.
- We don't need a full backend or HTTP stack here; instead we verify the behavior of the core helpers (`mergeSpecs`, `formatDefinition`) directly against in-memory OpenAPI objects.
- Higher-level integration/E2E tests can verify that the resulting OpenAPI is served correctly, but these unit tests pin down the transformation contract and make refactors much safer.

### What could still break / what's not covered?

- These tests use minimal sample specs; more complex OpenAPI features (security schemes, shared components, vendor extensions) are not exhaustively covered.
- They don't verify how Protobuf files are compiled into OpenAPI—only what happens after OpenAPI objects exist in memory.
- Runtime wiring (config for which plugins to include, error handling when fetching specs) is exercised only indirectly and could still regress.

### What risks or follow-ups remain?

- As we add more plugins or OpenAPI features, we may want additional fixtures that cover:
  - Specs with overlapping paths or conflicting metadata.
  - Specs that use advanced components/refs to ensure they survive merging intact.
- We may later complement these tests with an integration test that runs the full "fetch OpenAPI from plugin → aggregate → store/serve" pipeline using a small test backend.