### PR TITLE
630:P1 Stabilize catalog filter tests for deterministic async behavior

### DIFF
--- a/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
@@ -263,12 +263,7 @@ describe('<EntityListProvider />', () => {
       expect(result.current.entities.length).toBe(1);
     });
     expect(result.current.totalItems).toBe(1);
-
-    await expect(() =>
-      waitFor(() => {
-        expect(mockCatalogApi.getEntities).not.toHaveBeenCalledTimes(1);
-      }),
-    ).rejects.toThrow();
+    expect(mockCatalogApi.getEntities).toHaveBeenCalledTimes(1);
   });
 
   it('debounces multiple filter changes', async () => {
@@ -895,40 +890,50 @@ describe(`<EntityListProvider pagination={{ mode: 'offset' }} />`, () => {
   });
 
   it('fetch when frontend filters change', async () => {
-    const { result } = renderHook(() => useEntityList(), {
-      wrapper: createWrapper({ pagination }),
-    });
+    jest.useFakeTimers();
+    try {
+      const { result } = renderHook(() => useEntityList(), {
+        wrapper: createWrapper({ pagination }),
+      });
 
-    await waitFor(() => {
+      await act(async () => {
+        jest.advanceTimersByTime(20);
+        await Promise.resolve();
+      });
+
       expect(result.current.entities.length).toBe(2);
       expect(mockCatalogApi.queryEntities).toHaveBeenCalledTimes(1);
-    });
 
-    act(() =>
-      result.current.updateFilters({
-        user: EntityUserFilter.owned(ownershipEntityRefs),
-      }),
-    );
+      act(() =>
+        result.current.updateFilters({
+          user: EntityUserFilter.owned(ownershipEntityRefs),
+        }),
+      );
 
-    await waitFor(() => {
+      await act(async () => {
+        jest.advanceTimersByTime(20);
+        await Promise.resolve();
+      });
+
       expect(result.current.entities.length).toBe(1);
-    });
-
-    await waitFor(() => {
       expect(mockCatalogApi.queryEntities).toHaveBeenCalledTimes(2);
-    });
 
-    act(() =>
-      result.current.updateFilters({
-        user: EntityUserFilter.owned(ownershipEntityRefs),
-      }),
-    );
+      act(() =>
+        result.current.updateFilters({
+          user: EntityUserFilter.owned(ownershipEntityRefs),
+        }),
+      );
 
-    await expect(() =>
-      waitFor(() => {
-        expect(mockCatalogApi.queryEntities).toHaveBeenCalledTimes(3);
-      }),
-    ).rejects.toThrow();
+      await act(async () => {
+        jest.advanceTimersByTime(20);
+        await Promise.resolve();
+      });
+
+      expect(mockCatalogApi.queryEntities).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    }
   });
 
   it('fetch when limit change', async () => {


### PR DESCRIPTION
Closes #5

## Summary
- replace brittle negative `waitFor(...).rejects.toThrow()` assertions with deterministic direct call-count assertions
- stabilize frontend-only filter-change behavior test by using controlled fake timers around debounced updates
- keep scope test-only in `useEntityListProvider.test.tsx` with no production code changes

## How to run relevant tests
- yarn test --no-watch plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx

## Evidence (behavior now protected)
- frontend-only filter updates no longer rely on timing-sensitive negative waits
- debounced filter updates are asserted in deterministic before/after timer phases
- catalog entity list filter tests are less flaky in CI timing variance scenarios