### PR TITLE
630:P1 Improve test infrastructure docs for TestDatabases and Docker-disabled runs

### DIFF
--- a/packages/backend-test-utils/README.md
+++ b/packages/backend-test-utils/README.md
@@ -12,6 +12,30 @@ cd plugins/my-plugin-backend
 yarn add --dev @backstage/backend-test-utils
 ```
 
+## TestDatabases quick usage
+
+`TestDatabases` helps run the same integration test logic against one or more
+database engines.
+
+```ts
+import { TestDatabases } from '@backstage/backend-test-utils';
+
+describe('my plugin', () => {
+  const databases = TestDatabases.create();
+
+  it.each(databases.eachSupportedId())('works on %p', async databaseId => {
+    const knex = await databases.init(databaseId);
+    // run migrations, then execute assertions against your service/router
+  });
+});
+```
+
+For fast local iteration, disable Docker-backed database targets:
+
+```sh
+BACKSTAGE_TEST_DISABLE_DOCKER=1 yarn test --no-watch plugins/my-plugin-backend/src
+```
+
 ## Environment variables
 
 - `BACKSTAGE_TEST_DISABLE_DOCKER`


### PR DESCRIPTION
Closes #7

## Summary
- document `BACKSTAGE_TEST_DISABLE_DOCKER=1` behavior in backend testing docs
- add a practical `TestDatabases + startTestBackend` plugin testing pattern example
- add a concise `TestDatabases` quick usage section to `@backstage/backend-test-utils` README
- keep scope documentation-only, no production code or test logic changes

## How to verify
- yarn prettier --check docs/backend-system/building-plugins-and-modules/02-testing.md packages/backend-test-utils/README.md

## Evidence (behavior now protected)
- contributors now have explicit guidance for consistent local vs CI DB test setup
- Docker-disabled local runs are clearly documented to reduce setup failures
- plugin teams have a reusable integration/data test pattern for `TestDatabases`