### PR TITLE
630:P2 [SonarQube] Ensure SSE error responses are properly completed in messages endpoint

### DIFF
--- a/plugins/mcp-actions-backend/src/plugin.test.ts
+++ b/plugins/mcp-actions-backend/src/plugin.test.ts
@@ -82,6 +82,23 @@ describe('Mcp Backend', () => {
     };
   };
 
+  const fetchWithTimeout = async (
+    url: string,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const controller = new AbortController();
+    const timeoutHandle = setTimeout(() => controller.abort(), 2_000);
+
+    try {
+      return await fetch(url, {
+        ...init,
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeoutHandle);
+    }
+  };
+
   it('should support streamable spec', async () => {
     const { client, serverAddress } = await getContext();
     const transport = new StreamableHTTPClientTransport(
@@ -194,6 +211,33 @@ describe('Mcp Backend', () => {
     );
     expect('text' in firstContent && firstContent.text).toContain(
       'Actions must be invoked by a service, not a user',
+    );
+  });
+
+  it('returns completed 400 response when sessionId is missing', async () => {
+    const { serverAddress } = await getContext();
+
+    const response = await fetchWithTimeout(
+      `${serverAddress}/api/mcp-actions/v1/sse/messages`,
+      { method: 'POST' },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.text()).resolves.toBe('sessionId is required');
+  });
+
+  it('returns completed 400 response for unknown sessionId', async () => {
+    const { serverAddress } = await getContext();
+    const sessionId = 'unknown-session-id';
+
+    const response = await fetchWithTimeout(
+      `${serverAddress}/api/mcp-actions/v1/sse/messages?sessionId=${sessionId}`,
+      { method: 'POST' },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.text()).resolves.toBe(
+      `No transport found for sessionId "${sessionId}"`,
     );
   });
 });

--- a/plugins/mcp-actions-backend/src/routers/createSseRouter.ts
+++ b/plugins/mcp-actions-backend/src/routers/createSseRouter.ts
@@ -55,7 +55,7 @@ export const createSseRouter = ({
     const sessionId = req.query.sessionId as string;
 
     if (!sessionId) {
-      res.status(400).contentType('text/plain').write('sessionId is required');
+      res.status(400).contentType('text/plain').send('sessionId is required');
       return;
     }
 
@@ -66,7 +66,7 @@ export const createSseRouter = ({
       res
         .status(400)
         .contentType('text/plain')
-        .write(`No transport found for sessionId "${sessionId}"`);
+        .send(`No transport found for sessionId "${sessionId}"`);
     }
   });
   return router;


### PR DESCRIPTION
Closes #24

## Summary
- Updated SSE `/messages` error paths in `createSseRouter` to return completed responses.
- Replaced `.write(...)` with `.send(...)` for:
  - missing `sessionId`
  - unknown `sessionId`
- Added tests covering both error branches to ensure deterministic 400 behavior.

## Verification
- `yarn test --no-watch plugins/mcp-actions-backend/src/plugin.test.ts`

## Evidence
- POST `/api/mcp-actions/v1/sse/messages` now returns a completed `400` with clear text when `sessionId` is missing.
- POST `/api/mcp-actions/v1/sse/messages?sessionId=<invalid>` now returns a completed `400` with clear text when transport is not found.
- Error responses no longer risk hanging due to incomplete response writes.

Time log in hours

- Triage/Understand: 0:15
- Plan: 0:15
- Implement: 0:30
- Verify: 0:15
- PR overhead: 0:15
- Review time (as reviewer): 0:00
- Rework after review: 0:15
- Session total: 1:45