### PR TITLE
630:P2 [ChatGPT] Encapsulate SSE session map to reduce hidden mutable state

### DIFF
--- a/plugins/mcp-actions-backend/src/routers/SseSessionStore.test.ts
+++ b/plugins/mcp-actions-backend/src/routers/SseSessionStore.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { EventEmitter } from 'node:events';
+import { Response } from 'express';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import { SseSessionStore } from './SseSessionStore';
+
+describe('SseSessionStore', () => {
+  function createTransport(sessionId: string): SSEServerTransport {
+    return { sessionId } as unknown as SSEServerTransport;
+  }
+
+  it('registers and finds transports by session id', () => {
+    const store = new SseSessionStore();
+    const transport = createTransport('session-a');
+    const response = new EventEmitter() as unknown as Response;
+
+    store.register(transport, response);
+
+    expect(store.find('session-a')).toBe(transport);
+  });
+
+  it('removes transport when connection closes', () => {
+    const store = new SseSessionStore();
+    const transportA = createTransport('session-a');
+    const transportB = createTransport('session-b');
+    const responseEmitterA = new EventEmitter();
+    const responseEmitterB = new EventEmitter();
+
+    store.register(transportA, responseEmitterA as unknown as Response);
+    store.register(transportB, responseEmitterB as unknown as Response);
+
+    responseEmitterA.emit('close');
+
+    expect(store.find('session-a')).toBeUndefined();
+    expect(store.find('session-b')).toBe(transportB);
+  });
+});

--- a/plugins/mcp-actions-backend/src/routers/SseSessionStore.ts
+++ b/plugins/mcp-actions-backend/src/routers/SseSessionStore.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Response } from 'express';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+
+export class SseSessionStore {
+  readonly #transportsBySessionId = new Map<string, SSEServerTransport>();
+
+  register(transport: SSEServerTransport, response: Response): void {
+    this.#transportsBySessionId.set(transport.sessionId, transport);
+
+    response.on('close', () => {
+      this.#transportsBySessionId.delete(transport.sessionId);
+    });
+  }
+
+  find(sessionId: string): SSEServerTransport | undefined {
+    return this.#transportsBySessionId.get(sessionId);
+  }
+}

--- a/plugins/mcp-actions-backend/src/routers/createSseRouter.ts
+++ b/plugins/mcp-actions-backend/src/routers/createSseRouter.ts
@@ -18,6 +18,7 @@ import { Router } from 'express';
 import { McpService } from '../services/McpService';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { HttpAuthService } from '@backstage/backend-plugin-api';
+import { SseSessionStore } from './SseSessionStore';
 
 /**
  * Legacy SSE endpoint for older clients, hopefully will not be needed for much longer.
@@ -30,7 +31,7 @@ export const createSseRouter = ({
   httpAuth: HttpAuthService;
 }): Router => {
   const router = PromiseRouter();
-  const transportsToSessionId = new Map<string, SSEServerTransport>();
+  const sessionStore = new SseSessionStore();
 
   router.get('/', async (req, res) => {
     const server = mcpService.getServer({
@@ -42,11 +43,7 @@ export const createSseRouter = ({
       res,
     );
 
-    transportsToSessionId.set(transport.sessionId, transport);
-
-    res.on('close', () => {
-      transportsToSessionId.delete(transport.sessionId);
-    });
+    sessionStore.register(transport, res);
 
     await server.connect(transport);
   });
@@ -59,7 +56,7 @@ export const createSseRouter = ({
       return;
     }
 
-    const transport = transportsToSessionId.get(sessionId);
+    const transport = sessionStore.find(sessionId);
     if (transport) {
       await transport.handlePostMessage(req, res, req.body);
     } else {


### PR DESCRIPTION
Closes #25

## Summary
- Introduced `SseSessionStore` to encapsulate SSE session transport state.
- Refactored `createSseRouter` to use the store instead of directly mutating a local `Map`.
- Kept external SSE protocol behavior unchanged.

## Verification
- `yarn test --no-watch plugins/mcp-actions-backend/src/routers/SseSessionStore.test.ts plugins/mcp-actions-backend/src/plugin.test.ts`

## Evidence
- Session registration and lookup are now managed through a dedicated abstraction.
- Automated tests verify sessions are registered and removed when the connection closes.

Time log in hours - 
- Triage/Understand: 0:15
- Plan: 0:15
- Implement: 0:30
- Verify: 0:15
- PR overhead: 0:15
- Review time (as reviewer): 0:00
- Rework after review: 0:15
- Session total: 1:45