### PR TITLE
630:P2 [ChatGPT] refactor(mcp-actions): deduplicate MCP tool metadata test assertions

### DIFF
--- a/plugins/mcp-actions-backend/src/plugin.test.ts
+++ b/plugins/mcp-actions-backend/src/plugin.test.ts
@@ -24,8 +24,21 @@ import {
   CallToolResultSchema,
   ListToolsResultSchema,
 } from '@modelcontextprotocol/sdk/types.js';
+import { expectedMcpTool } from './testUtils/expectedMcpTool';
 
 describe('Mcp Backend', () => {
+  const expectedMakeGreetingTool = expectedMcpTool({
+    name: 'make-greeting',
+    title: 'Make Greeting',
+    description: 'Make a greeting',
+    inputProperties: {
+      name: {
+        type: 'string',
+      },
+    },
+    required: ['name'],
+  });
+
   const mockPluginWithActions = createBackendPlugin({
     pluginId: 'local',
     register({ registerInit }) {
@@ -97,30 +110,7 @@ describe('Mcp Backend', () => {
       ListToolsResultSchema,
     );
 
-    expect(result.tools).toEqual([
-      {
-        annotations: {
-          destructiveHint: true,
-          idempotentHint: false,
-          openWorldHint: false,
-          readOnlyHint: false,
-          title: 'Make Greeting',
-        },
-        description: 'Make a greeting',
-        inputSchema: {
-          $schema: 'http://json-schema.org/draft-07/schema#',
-          additionalProperties: false,
-          properties: {
-            name: {
-              type: 'string',
-            },
-          },
-          required: ['name'],
-          type: 'object',
-        },
-        name: 'make-greeting',
-      },
-    ]);
+    expect(result.tools).toEqual([expectedMakeGreetingTool]);
   });
 
   it('should support sse spec', async () => {
@@ -140,30 +130,7 @@ describe('Mcp Backend', () => {
 
     await client.close();
 
-    expect(result.tools).toEqual([
-      {
-        annotations: {
-          destructiveHint: true,
-          idempotentHint: false,
-          openWorldHint: false,
-          readOnlyHint: false,
-          title: 'Make Greeting',
-        },
-        description: 'Make a greeting',
-        inputSchema: {
-          $schema: 'http://json-schema.org/draft-07/schema#',
-          additionalProperties: false,
-          properties: {
-            name: {
-              type: 'string',
-            },
-          },
-          required: ['name'],
-          type: 'object',
-        },
-        name: 'make-greeting',
-      },
-    ]);
+    expect(result.tools).toEqual([expectedMakeGreetingTool]);
   });
 
   it('should execute a registered action via tools/call', async () => {

--- a/plugins/mcp-actions-backend/src/services/McpService.test.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.test.ts
@@ -23,8 +23,21 @@ import {
   CallToolResultSchema,
   ListToolsResultSchema,
 } from '@modelcontextprotocol/sdk/types.js';
+import { expectedMcpTool } from '../testUtils/expectedMcpTool';
 
 describe('McpService', () => {
+  const expectedMockActionTool = expectedMcpTool({
+    name: 'mock-action',
+    title: 'Test',
+    description: 'Test',
+    inputProperties: {
+      input: {
+        type: 'string',
+      },
+    },
+    required: ['input'],
+  });
+
   it('should list the available actions as tools in the mcp backend', async () => {
     const mockActionsRegistry = actionsRegistryServiceMock();
     mockActionsRegistry.register({
@@ -66,30 +79,7 @@ describe('McpService', () => {
       ListToolsResultSchema,
     );
 
-    expect(result.tools).toEqual([
-      {
-        annotations: {
-          destructiveHint: true,
-          idempotentHint: false,
-          openWorldHint: false,
-          readOnlyHint: false,
-          title: 'Test',
-        },
-        description: 'Test',
-        inputSchema: {
-          $schema: 'http://json-schema.org/draft-07/schema#',
-          additionalProperties: false,
-          properties: {
-            input: {
-              type: 'string',
-            },
-          },
-          required: ['input'],
-          type: 'object',
-        },
-        name: 'mock-action',
-      },
-    ]);
+    expect(result.tools).toEqual([expectedMockActionTool]);
   });
 
   it('should call the action when the tool is invoked', async () => {

--- a/plugins/mcp-actions-backend/src/testUtils/expectedMcpTool.ts
+++ b/plugins/mcp-actions-backend/src/testUtils/expectedMcpTool.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+type ToolInputProperty = { type: string };
+
+export function expectedMcpTool(options: {
+  name: string;
+  title: string;
+  description: string;
+  inputProperties: Record<string, ToolInputProperty>;
+  required: string[];
+}) {
+  const { name, title, description, inputProperties, required } = options;
+
+  return {
+    annotations: {
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false,
+      readOnlyHint: false,
+      title,
+    },
+    description,
+    inputSchema: {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      additionalProperties: false,
+      properties: inputProperties,
+      required,
+      type: 'object',
+    },
+    name,
+  };
+}


### PR DESCRIPTION
## Summary
- Introduce a shared `expectedMcpTool` helper for MCP tool metadata assertions.
- Replace repeated inline tool metadata objects in `plugin.test.ts` and `McpService.test.ts` with helper-based expectations.
- Keep assertion strictness intact while reducing test maintenance overhead.

Closes #27

## Test plan
- [x] `yarn test --no-watch plugins/mcp-actions-backend/src/plugin.test.ts plugins/mcp-actions-backend/src/services/McpService.test.ts`