### PR TITLE
630:P2 refactor(mcp-actions): centralize MCP error message policy

### DIFF
--- a/plugins/mcp-actions-backend/src/services/handleErrors.test.ts
+++ b/plugins/mcp-actions-backend/src/services/handleErrors.test.ts
@@ -14,17 +14,33 @@
  * limitations under the License.
  */
 
-import { NotFoundError } from '@backstage/errors';
+import {
+  AuthenticationError,
+  NotAllowedError,
+  NotFoundError,
+} from '@backstage/errors';
 import { describeBackstageErrorForMcp, handleErrors } from './handleErrors';
 
 describe('describeBackstageErrorForMcp', () => {
-  it('returns a description for a known Backstage error', () => {
-    const err = new NotFoundError('nothing here');
-    const result = describeBackstageErrorForMcp(err);
+  it.each([
+    {
+      error: new NotFoundError('nothing here'),
+      expected: 'NotFoundError: nothing here',
+    },
+    {
+      error: new AuthenticationError('missing token'),
+      expected: 'AuthenticationError: missing token',
+    },
+    {
+      error: new NotAllowedError('service credentials required'),
+      expected: 'NotAllowedError: service credentials required',
+    },
+  ])('returns a description for $error.name', ({ error, expected }) => {
+    const result = describeBackstageErrorForMcp(error);
 
     expect(result).toEqual({
       handled: true,
-      description: 'NotFoundError: nothing here',
+      description: expected,
     });
   });
 

--- a/plugins/mcp-actions-backend/src/services/handleErrors.ts
+++ b/plugins/mcp-actions-backend/src/services/handleErrors.ts
@@ -23,17 +23,19 @@ import {
 
 import { Server as McpServer } from '@modelcontextprotocol/sdk/server/index.js';
 
-const knownErrors = new Set([
-  'InputError',
-  'AuthenticationError',
-  'NotAllowedError',
-  'NotFoundError',
-  'ConflictError',
-  'NotModifiedError',
-  'NotImplementedError',
-  'ResponseError',
-  'ServiceUnavailableError',
-]);
+type ErrorMessageFormatter = (message: string) => string;
+
+const errorMessagePolicy: Record<string, ErrorMessageFormatter> = {
+  InputError: message => `InputError: ${message}`,
+  AuthenticationError: message => `AuthenticationError: ${message}`,
+  NotAllowedError: message => `NotAllowedError: ${message}`,
+  NotFoundError: message => `NotFoundError: ${message}`,
+  ConflictError: message => `ConflictError: ${message}`,
+  NotModifiedError: message => `NotModifiedError: ${message}`,
+  NotImplementedError: message => `NotImplementedError: ${message}`,
+  ResponseError: message => `ResponseError: ${message}`,
+  ServiceUnavailableError: message => `ServiceUnavailableError: ${message}`,
+};
 
 // Extracts the cause error, if the provided error is `ResponseError` or
 // `ForwardedError` with a cause.
@@ -65,9 +67,10 @@ export function describeBackstageErrorForMcp(
     const serialized = serializeError(err);
 
     const { name, message } = extractCause(serialized);
+    const formatter = errorMessagePolicy[name];
 
-    if (knownErrors.has(name)) {
-      return { handled: true, description: `${name}: ${message}` };
+    if (formatter) {
+      return { handled: true, description: formatter(message) };
     }
   }
 


### PR DESCRIPTION
## Summary
- Replace the magic-string `knownErrors` set in `handleErrors.ts` with a centralized `errorMessagePolicy` map.
- Keep MCP-facing error messages unchanged while making the mapping strategy explicit and easier to extend.
- Expand `handleErrors.test.ts` to cover representative Backstage errors (`NotFoundError`, `AuthenticationError`, `NotAllowedError`) plus existing unhandled behavior.

Closes #26

## Test plan
- [x] `yarn test --no-watch plugins/mcp-actions-backend/src/services/handleErrors.test.ts plugins/mcp-actions-backend/src/services/McpService.test.ts`