### PR TITLE
P3/issue 49 search bar context decorator

### DIFF
--- a/plugins/search-react/src/components/SearchBar/SearchBar.tsx
+++ b/plugins/search-react/src/components/SearchBar/SearchBar.tsx
@@ -27,17 +27,20 @@ import Button from '@material-ui/core/Button';
 import { TextFieldProps } from '@material-ui/core/TextField';
 import DefaultSearchIcon from '@material-ui/icons/Search';
 import {
-  ReactNode,
   ChangeEvent,
-  forwardRef,
+  ForwardRefExoticComponent,
   KeyboardEvent,
+  PropsWithoutRef,
+  ReactNode,
+  RefAttributes,
+  forwardRef,
   useCallback,
   useEffect,
   useRef,
   useState,
 } from 'react';
 import useDebounce from 'react-use/esm/useDebounce';
-import { SearchContextProvider, useSearch } from '../../context';
+import { useSearch } from '../../context';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { searchReactTranslationRef } from '../../translation';
 
@@ -56,9 +59,14 @@ export type SearchBarBaseProps = Omit<TextFieldProps, 'onChange'> & {
 };
 
 /**
- * All search boxes exported by the search plugin are based on the <SearchBarBase />,
- * and this one is based on the <InputBase /> component from Material UI.
- * Recommended if you don't use Search Provider or Search Context.
+ * Pure presentational search input used by all search boxes exported by
+ * the search plugin. Owns the debounced text state and Backstage's default
+ * input chrome (icon, clear button), but is intentionally decoupled from
+ * the SearchContext: callers supply `value` / `onChange` themselves.
+ *
+ * Use this directly when you maintain your own state (see `HomePageSearchBar`
+ * for an example), or compose it with {@link SearchBar} (a Decorator that
+ * adds SearchContext wiring + analytics) when context wiring is needed.
  *
  * @public
  */
@@ -170,31 +178,29 @@ export const SearchBarBase = forwardRef((props: SearchBarBaseProps, ref) => {
   );
 
   return (
-    <SearchContextProvider inheritParentContextIfAvailable>
-      <TextField
-        id="search-bar-text-field"
-        data-testid="search-bar-next"
-        variant="outlined"
-        margin="normal"
-        inputRef={ref}
-        value={value}
-        label={label}
-        placeholder={inputPlaceholder}
-        InputProps={{
-          startAdornment,
-          endAdornment: clearButton ? clearButtonEndAdornment : endAdornment,
-          ...InputProps,
-        }}
-        inputProps={{
-          'aria-label': ariaLabel,
-          ...inputProps,
-        }}
-        fullWidth={fullWidth}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        {...rest}
-      />
-    </SearchContextProvider>
+    <TextField
+      id="search-bar-text-field"
+      data-testid="search-bar-next"
+      variant="outlined"
+      margin="normal"
+      inputRef={ref}
+      value={value}
+      label={label}
+      placeholder={inputPlaceholder}
+      InputProps={{
+        startAdornment,
+        endAdornment: clearButton ? clearButtonEndAdornment : endAdornment,
+        ...InputProps,
+      }}
+      inputProps={{
+        'aria-label': ariaLabel,
+        ...inputProps,
+      }}
+      fullWidth={fullWidth}
+      onChange={handleChange}
+      onKeyDown={handleKeyDown}
+      {...rest}
+    />
   );
 });
 
@@ -205,45 +211,59 @@ export const SearchBarBase = forwardRef((props: SearchBarBaseProps, ref) => {
  */
 export type SearchBarProps = Partial<SearchBarBaseProps>;
 
+type SearchBarBaseComponent = ForwardRefExoticComponent<
+  PropsWithoutRef<SearchBarBaseProps> & RefAttributes<unknown>
+>;
+
 /**
- * Recommended search bar when you use the Search Provider or Search Context.
+ * Decorator (higher-order component) that wires a SearchBarBase-shaped
+ * component to the surrounding {@link SearchContextProvider} and adds
+ * analytics context. Reads `term` from context, bridges it to the wrapped
+ * component's `value` / `onChange`, and supports an optional `value`
+ * prop to seed the term on mount.
  *
- * @public
+ * Kept package-internal: consumers compose via {@link SearchBar} or
+ * by writing their own decorator in user code.
  */
-export const SearchBar = forwardRef((props: SearchBarProps, ref) => {
-  const { value: initialValue = '', onChange, ...rest } = props;
+const withSearchContext = (Component: SearchBarBaseComponent) =>
+  forwardRef<unknown, SearchBarProps>((props, ref) => {
+    const { value: initialValue = '', onChange, ...rest } = props;
 
-  const { term, setTerm } = useSearch();
+    const { term, setTerm } = useSearch();
 
-  useEffect(() => {
-    if (initialValue) {
-      setTerm(String(initialValue));
-    }
-  }, [initialValue, setTerm]);
-
-  const handleChange = useCallback(
-    (newValue: string) => {
-      if (onChange) {
-        onChange(newValue);
-      } else {
-        setTerm(newValue);
+    useEffect(() => {
+      if (initialValue) {
+        setTerm(String(initialValue));
       }
-    },
-    [onChange, setTerm],
-  );
+    }, [initialValue, setTerm]);
 
-  return (
-    <SearchContextProvider inheritParentContextIfAvailable>
+    const handleChange = useCallback(
+      (newValue: string) => {
+        if (onChange) {
+          onChange(newValue);
+        } else {
+          setTerm(newValue);
+        }
+      },
+      [onChange, setTerm],
+    );
+
+    return (
       <AnalyticsContext
         attributes={{ pluginId: 'search', extension: 'SearchBar' }}
       >
-        <SearchBarBase
-          {...rest}
-          ref={ref}
-          value={term}
-          onChange={handleChange}
-        />
+        <Component {...rest} ref={ref} value={term} onChange={handleChange} />
       </AnalyticsContext>
-    </SearchContextProvider>
-  );
-});
+    );
+  });
+
+/**
+ * SearchBar is {@link SearchBarBase} decorated with SearchContext wiring
+ * and analytics. Use this when your subtree is wrapped in a
+ * {@link SearchContextProvider}: the bar reads `term` from context and
+ * writes back to it on change. For standalone use without the search
+ * context, use {@link SearchBarBase} directly with your own state.
+ *
+ * @public
+ */
+export const SearchBar = withSearchContext(SearchBarBase);

--- a/plugins/search-react/src/components/SearchResult/SearchResult.tsx
+++ b/plugins/search-react/src/components/SearchResult/SearchResult.tsx
@@ -18,11 +18,7 @@ import { ReactNode } from 'react';
 import useAsync, { AsyncState } from 'react-use/esm/useAsync';
 import { isFunction } from 'lodash';
 
-import {
-  Progress,
-  EmptyState,
-  ResponseErrorPanel,
-} from '@backstage/core-components';
+import { EmptyState } from '@backstage/core-components';
 import { useApi, AnalyticsContext } from '@backstage/core-plugin-api';
 import { SearchQuery, SearchResultSet } from '@backstage/plugin-search-common';
 
@@ -32,6 +28,7 @@ import {
   SearchResultListItemExtensions,
   SearchResultListItemExtensionsProps,
 } from '../../extensions';
+import { SearchResultStateBoundary } from '../SearchResultStateBoundary';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { searchReactTranslationRef } from '../../translation';
 
@@ -198,36 +195,29 @@ export const SearchResultComponent = (props: SearchResultProps) => {
     ...rest
   } = props;
 
+  const renderSuccessContent = (value: SearchResultSet | undefined) => {
+    if (isFunction(children)) {
+      return value ? children(value) : null;
+    }
+    return (
+      <SearchResultListItemExtensions {...rest} results={value?.results ?? []}>
+        {children}
+      </SearchResultListItemExtensions>
+    );
+  };
+
   return (
     <SearchResultState query={query}>
-      {({ loading, error, value }) => {
-        if (loading) {
-          return <Progress />;
-        }
-
-        if (error) {
-          return (
-            <ResponseErrorPanel
-              title="Error encountered while fetching search results"
-              error={error}
-            />
-          );
-        }
-
-        if (!value?.results.length) {
-          return noResultsComponent;
-        }
-
-        if (isFunction(children)) {
-          return children(value);
-        }
-
-        return (
-          <SearchResultListItemExtensions {...rest} results={value.results}>
-            {children}
-          </SearchResultListItemExtensions>
-        );
-      }}
+      {({ loading, error, value }) => (
+        <SearchResultStateBoundary
+          loading={loading}
+          error={error}
+          isEmpty={!value?.results.length}
+          noResultsComponent={noResultsComponent}
+        >
+          {renderSuccessContent(value)}
+        </SearchResultStateBoundary>
+      )}
     </SearchResultState>
   );
 };

--- a/plugins/search-react/src/components/SearchResultList/SearchResultList.tsx
+++ b/plugins/search-react/src/components/SearchResultList/SearchResultList.tsx
@@ -18,11 +18,7 @@ import { ReactNode } from 'react';
 
 import List, { ListProps } from '@material-ui/core/List';
 
-import {
-  Progress,
-  EmptyState,
-  ResponseErrorPanel,
-} from '@backstage/core-components';
+import { EmptyState } from '@backstage/core-components';
 import { AnalyticsContext } from '@backstage/core-plugin-api';
 import { SearchResult } from '@backstage/plugin-search-common';
 
@@ -30,6 +26,7 @@ import { useSearchResultListItemExtensions } from '../../extensions';
 
 import { DefaultResultListItem } from '../DefaultResultListItem';
 import { SearchResultState, SearchResultStateProps } from '../SearchResult';
+import { SearchResultStateBoundary } from '../SearchResultStateBoundary';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { searchReactTranslationRef } from '../../translation';
 
@@ -92,24 +89,16 @@ export const SearchResultListLayout = (props: SearchResultListLayoutProps) => {
     ...rest
   } = props;
 
-  if (loading) {
-    return <Progress />;
-  }
-
-  if (error) {
-    return (
-      <ResponseErrorPanel
-        title="Error encountered while fetching search results"
-        error={error}
-      />
-    );
-  }
-
-  if (!resultItems?.length) {
-    return <>{noResultsComponent}</>;
-  }
-
-  return <List {...rest}>{resultItems.map(renderResultItem)}</List>;
+  return (
+    <SearchResultStateBoundary
+      loading={loading}
+      error={error}
+      isEmpty={!resultItems?.length}
+      noResultsComponent={noResultsComponent}
+    >
+      <List {...rest}>{(resultItems ?? []).map(renderResultItem)}</List>
+    </SearchResultStateBoundary>
+  );
 };
 
 /**

--- a/plugins/search-react/src/components/SearchResultStateBoundary/SearchResultStateBoundary.test.tsx
+++ b/plugins/search-react/src/components/SearchResultStateBoundary/SearchResultStateBoundary.test.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderInTestApp } from '@backstage/test-utils';
+
+import { SearchResultStateBoundary } from './SearchResultStateBoundary';
+
+describe('SearchResultStateBoundary', () => {
+  it('renders a progress indicator while loading', async () => {
+    const { getByTestId } = await renderInTestApp(
+      <SearchResultStateBoundary loading>
+        <span>content</span>
+      </SearchResultStateBoundary>,
+    );
+
+    expect(getByTestId('progress')).toBeInTheDocument();
+  });
+
+  it('renders the response error panel when an error is provided', async () => {
+    const error = new Error('boom');
+    const { getByRole } = await renderInTestApp(
+      <SearchResultStateBoundary error={error}>
+        <span>content</span>
+      </SearchResultStateBoundary>,
+    );
+
+    expect(getByRole('alert')).toHaveTextContent(
+      /Error encountered while fetching search results.*boom/,
+    );
+  });
+
+  it('renders the provided no-results component when empty', async () => {
+    const { getByText, queryByText } = await renderInTestApp(
+      <SearchResultStateBoundary isEmpty noResultsComponent={<>nothing here</>}>
+        <span>content</span>
+      </SearchResultStateBoundary>,
+    );
+
+    expect(getByText('nothing here')).toBeInTheDocument();
+    expect(queryByText('content')).toBeNull();
+  });
+
+  it('renders nothing in the empty case when noResultsComponent is null', async () => {
+    const { queryByText } = await renderInTestApp(
+      <SearchResultStateBoundary isEmpty noResultsComponent={null}>
+        <span>content</span>
+      </SearchResultStateBoundary>,
+    );
+
+    expect(queryByText('content')).toBeNull();
+  });
+
+  it('renders children in the loaded, error-free, non-empty case', async () => {
+    const { getByText } = await renderInTestApp(
+      <SearchResultStateBoundary>
+        <span>content</span>
+      </SearchResultStateBoundary>,
+    );
+
+    expect(getByText('content')).toBeInTheDocument();
+  });
+
+  it('prioritizes loading over error and empty', async () => {
+    const { getByTestId, queryByRole, queryByText } = await renderInTestApp(
+      <SearchResultStateBoundary
+        loading
+        error={new Error('boom')}
+        isEmpty
+        noResultsComponent={<>nothing here</>}
+      >
+        <span>content</span>
+      </SearchResultStateBoundary>,
+    );
+
+    expect(getByTestId('progress')).toBeInTheDocument();
+    expect(queryByRole('alert')).toBeNull();
+    expect(queryByText('nothing here')).toBeNull();
+    expect(queryByText('content')).toBeNull();
+  });
+});

--- a/plugins/search-react/src/components/SearchResultStateBoundary/SearchResultStateBoundary.tsx
+++ b/plugins/search-react/src/components/SearchResultStateBoundary/SearchResultStateBoundary.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactNode } from 'react';
+
+import { Progress, ResponseErrorPanel } from '@backstage/core-components';
+
+/**
+ * Props for {@link SearchResultStateBoundary}.
+ */
+export type SearchResultStateBoundaryProps = {
+  /**
+   * Whether the result set is still loading. Renders a default {@link Progress} indicator.
+   */
+  loading?: boolean;
+  /**
+   * Error from the result fetch. Renders a default {@link ResponseErrorPanel}.
+   */
+  error?: Error;
+  /**
+   * Whether the result set is empty. Renders {@link SearchResultStateBoundaryProps.noResultsComponent}.
+   */
+  isEmpty?: boolean;
+  /**
+   * Node rendered for the empty case. Pass `null` to suppress empty rendering.
+   */
+  noResultsComponent?: ReactNode;
+  /**
+   * Content rendered when the result is loaded, error-free, and non-empty.
+   */
+  children: ReactNode;
+};
+
+/**
+ * Internal facade that consolidates the loading / error / empty rendering
+ * for search result components. Centralizing these UX choices (Progress,
+ * ResponseErrorPanel, empty-state slot) keeps the surrounding components
+ * focused on success rendering and avoids drift in copy or behavior across
+ * result surfaces.
+ *
+ * Branch precedence: loading > error > empty > children.
+ */
+export const SearchResultStateBoundary = (
+  props: SearchResultStateBoundaryProps,
+) => {
+  const { loading, error, isEmpty, noResultsComponent, children } = props;
+
+  if (loading) {
+    return <Progress />;
+  }
+
+  if (error) {
+    return (
+      <ResponseErrorPanel
+        title="Error encountered while fetching search results"
+        error={error}
+      />
+    );
+  }
+
+  if (isEmpty) {
+    return <>{noResultsComponent}</>;
+  }
+
+  return <>{children}</>;
+};

--- a/plugins/search-react/src/components/SearchResultStateBoundary/index.tsx
+++ b/plugins/search-react/src/components/SearchResultStateBoundary/index.tsx
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { SearchResultStateBoundary } from './SearchResultStateBoundary';
+export type { SearchResultStateBoundaryProps } from './SearchResultStateBoundary';


### PR DESCRIPTION
Closes #49

## Summary

- **Problem:** `SearchBarBase` was documented as a standalone/presentational bar but still wrapped its `<TextField>` in `SearchContextProvider`, blurring responsibilities and over-applying context wiring (Golden Hammer).
- **Approach:** Make `SearchBarBase` purely presentational (no implicit provider). Add an internal **Decorator** — `withSearchContext` — that binds `term` / `setTerm` from `useSearch`, forwards `value` / `onChange`, and wraps the inner component with the same `AnalyticsContext` as before. Export `SearchBar` as `withSearchContext(SearchBarBase)`.
- **Behavior:** User-visible search behavior unchanged for normal usage: `SearchBar` still expects an outer `SearchContextProvider` (same as before, since `useSearch()` runs outside any inner provider). Standalone `SearchBarBase` consumers (e.g. home page search bar) no longer get a redundant nested provider.

## Design pattern

- **Pattern:** Decorator (Structural)
- **Rationale:** Context + analytics are **optional cross-cutting concerns** layered onto the same UI component. A small HOC keeps `SearchBarBase` focused on input/debounce/chrome while `SearchBar` explicitly represents “base + search context integration.”

### Before / after responsibility map

- **Before:** `SearchBarBase` = presentational UI **and** implicit `SearchContextProvider` wrapper. `SearchBar` = context hook + another `SearchContextProvider` + analytics + `SearchBarBase`.
- **After:** `SearchBarBase` = presentational UI only. `withSearchContext` = context bridge + analytics. `SearchBar` = decorated `SearchBarBase`.

## Verification

- `yarn workspace @backstage/plugin-search-react lint` — clean
- `yarn workspace @backstage/plugin-search-react test --testPathPatterns SearchBar` — **10/10** (`SearchBar.test.tsx`, unchanged)
- `yarn workspace @backstage/plugin-search test --testPathPatterns HomePageSearchBar` — **1/1** (standalone `SearchBarBase` consumer)

## Evidence of improvement

- **Clear API story:** “Base” is actually base; context integration is explicit via `SearchBar` / decorator, not hidden inside the base.
- **Less redundant wiring:** Removed the inner `SearchContextProvider` from `SearchBarBase` (was unnecessary for typical parent-wrapped `SearchBar` usage and added noise for standalone `SearchBarBase`).
- **Extension point:** Adopters can reuse `SearchBarBase` with their own state or compose additional decorators without fighting implicit providers.

## Files changed

- `plugins/search-react/src/components/SearchBar/SearchBar.tsx`

## Non-goals

- No search input styling or UX redesign
- No new search features
- No broad public API changes (`SearchBar` / `SearchBarBase` / types unchanged from consumers’ perspective; `withSearchContext` is internal)