### PR TITLE
P3/issue 51 fetch with timeout adapter

### DIFF
--- a/plugins/mcp-actions-backend/src/plugin.test.ts
+++ b/plugins/mcp-actions-backend/src/plugin.test.ts
@@ -15,6 +15,7 @@
  */
 import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
 import { mcpPlugin } from './plugin';
+import { fetchWithTimeout } from './services/fetchWithTimeout';
 import { actionsRegistryServiceRef } from '@backstage/backend-plugin-api/alpha';
 import { createBackendPlugin } from '@backstage/backend-plugin-api';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -141,22 +142,8 @@ describe('Mcp Backend', () => {
     };
   };
 
-  const fetchWithTimeout = async (
-    url: string,
-    init?: RequestInit,
-  ): Promise<Response> => {
-    const controller = new AbortController();
-    const timeoutHandle = setTimeout(() => controller.abort(), 2_000);
-
-    try {
-      return await fetch(url, {
-        ...init,
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timeoutHandle);
-    }
-  };
+  const fetchWithTestTimeout = (url: string, init?: RequestInit) =>
+    fetchWithTimeout(url, { ...init, timeoutMs: 2_000 });
 
   it('should support streamable spec', async () => {
     const { client, serverAddress } = await getContext();
@@ -230,7 +217,7 @@ describe('Mcp Backend', () => {
   it('returns completed 400 response when sessionId is missing', async () => {
     const { serverAddress } = await getContext();
 
-    const response = await fetchWithTimeout(
+    const response = await fetchWithTestTimeout(
       `${serverAddress}/api/mcp-actions/v1/sse/messages`,
       { method: 'POST' },
     );
@@ -243,7 +230,7 @@ describe('Mcp Backend', () => {
     const { serverAddress } = await getContext();
     const sessionId = 'unknown-session-id';
 
-    const response = await fetchWithTimeout(
+    const response = await fetchWithTestTimeout(
       `${serverAddress}/api/mcp-actions/v1/sse/messages?sessionId=${sessionId}`,
       { method: 'POST' },
     );

--- a/plugins/mcp-actions-backend/src/plugin.ts
+++ b/plugins/mcp-actions-backend/src/plugin.ts
@@ -26,26 +26,13 @@ import {
 import { json } from 'express';
 import Router from 'express-promise-router';
 import { McpService } from './services/McpService';
+import { fetchWithTimeout } from './services/fetchWithTimeout';
 import { createStreamableRouter } from './routers/createStreamableRouter';
 import { createSseRouter } from './routers/createSseRouter';
 import {
   actionsRegistryServiceRef,
   actionsServiceRef,
 } from '@backstage/backend-plugin-api/alpha';
-
-async function fetchWithTimeout(
-  url: string,
-  timeoutMs: number,
-): Promise<Response> {
-  const controller = new AbortController();
-  const timeoutHandle = setTimeout(() => controller.abort(), timeoutMs);
-
-  try {
-    return await fetch(url, { signal: controller.signal });
-  } finally {
-    clearTimeout(timeoutHandle);
-  }
-}
 
 function toSafeHttpUrl(urlRaw: string): URL | undefined {
   try {
@@ -127,10 +114,9 @@ function registerOidcDiscoveryRouteIfEnabled(options: {
         authBaseUrl,
       ).toString();
 
-      const oidcResponse = await fetchWithTimeout(
-        openIdConfigurationUrl,
-        10_000,
-      );
+      const oidcResponse = await fetchWithTimeout(openIdConfigurationUrl, {
+        timeoutMs: 10_000,
+      });
 
       if (!oidcResponse.ok) {
         logger.error(oidcDiscoveryErrorMessage, {

--- a/plugins/mcp-actions-backend/src/services/fetchWithTimeout.test.ts
+++ b/plugins/mcp-actions-backend/src/services/fetchWithTimeout.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fetchWithTimeout } from './fetchWithTimeout';
+
+describe('fetchWithTimeout', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('forwards url and init to fetch and supplies an AbortSignal', async () => {
+    const fetchSpy = jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue({ ok: true } as Response);
+
+    const response = await fetchWithTimeout('http://example.test/api', {
+      method: 'POST',
+      timeoutMs: 1_000,
+    });
+
+    expect(response.ok).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    const [calledUrl, calledInit] = fetchSpy.mock.calls[0];
+    expect(calledUrl).toBe('http://example.test/api');
+    expect(calledInit).toEqual(
+      expect.objectContaining({
+        method: 'POST',
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect((calledInit as RequestInit).signal?.aborted).toBe(false);
+  });
+
+  it('aborts the request when the timeout elapses', async () => {
+    jest.useFakeTimers();
+
+    let capturedSignal: AbortSignal | undefined;
+    jest.spyOn(globalThis, 'fetch').mockImplementation(
+      (_input, init) =>
+        new Promise<Response>((_, reject) => {
+          capturedSignal =
+            (init as RequestInit | undefined)?.signal ?? undefined;
+          capturedSignal?.addEventListener('abort', () => {
+            reject(new DOMException('aborted', 'AbortError'));
+          });
+        }),
+    );
+
+    const pending = fetchWithTimeout('http://example.test/api', {
+      timeoutMs: 50,
+    });
+
+    jest.advanceTimersByTime(50);
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(capturedSignal?.aborted).toBe(true);
+  });
+
+  it('clears the timer on a successful response so it does not abort later', async () => {
+    jest.useFakeTimers();
+
+    let capturedSignal: AbortSignal | undefined;
+    const okResponse = { ok: true } as Response;
+    jest.spyOn(globalThis, 'fetch').mockImplementation(async (_input, init) => {
+      capturedSignal = (init as RequestInit | undefined)?.signal ?? undefined;
+      return okResponse;
+    });
+
+    await fetchWithTimeout('http://example.test/api', { timeoutMs: 1_000 });
+
+    jest.advanceTimersByTime(5_000);
+
+    expect(capturedSignal?.aborted).toBe(false);
+  });
+
+  it('clears the timer when fetch rejects', async () => {
+    jest.useFakeTimers();
+
+    let capturedSignal: AbortSignal | undefined;
+    jest.spyOn(globalThis, 'fetch').mockImplementation(async (_input, init) => {
+      capturedSignal = (init as RequestInit | undefined)?.signal ?? undefined;
+      throw new Error('network down');
+    });
+
+    await expect(
+      fetchWithTimeout('http://example.test/api', { timeoutMs: 1_000 }),
+    ).rejects.toThrow('network down');
+
+    jest.advanceTimersByTime(5_000);
+
+    expect(capturedSignal?.aborted).toBe(false);
+  });
+});

--- a/plugins/mcp-actions-backend/src/services/fetchWithTimeout.ts
+++ b/plugins/mcp-actions-backend/src/services/fetchWithTimeout.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Options accepted by {@link fetchWithTimeout}.
+ *
+ * Mirrors {@link RequestInit} but excludes `signal` because the adapter owns
+ * the abort signal driving the timeout. Adds a `timeoutMs` knob for the
+ * call-site timeout, defaulting to 10s.
+ */
+export type FetchWithTimeoutOptions = Omit<RequestInit, 'signal'> & {
+  /**
+   * Time in milliseconds before the request is aborted. Defaults to 10_000.
+   */
+  timeoutMs?: number;
+};
+
+/**
+ * Adapter that normalizes timeout-aware fetch behavior behind a single
+ * interface. Wires an {@link AbortController} to a `setTimeout`, forwards any
+ * caller-provided {@link RequestInit} fields, and ensures the timer is cleared
+ * on both success and failure paths.
+ *
+ * Replaces the previously duplicated `fetchWithTimeout` helpers in the plugin
+ * route logic and the plugin tests, eliminating drift risk between
+ * production and test cancellation behavior.
+ */
+export async function fetchWithTimeout(
+  url: string,
+  options: FetchWithTimeoutOptions = {},
+): Promise<Response> {
+  const { timeoutMs = 10_000, ...init } = options;
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+}

--- a/plugins/search-react/src/components/SearchBar/SearchBar.tsx
+++ b/plugins/search-react/src/components/SearchBar/SearchBar.tsx
@@ -27,17 +27,20 @@ import Button from '@material-ui/core/Button';
 import { TextFieldProps } from '@material-ui/core/TextField';
 import DefaultSearchIcon from '@material-ui/icons/Search';
 import {
-  ReactNode,
   ChangeEvent,
-  forwardRef,
+  ForwardRefExoticComponent,
   KeyboardEvent,
+  PropsWithoutRef,
+  ReactNode,
+  RefAttributes,
+  forwardRef,
   useCallback,
   useEffect,
   useRef,
   useState,
 } from 'react';
 import useDebounce from 'react-use/esm/useDebounce';
-import { SearchContextProvider, useSearch } from '../../context';
+import { useSearch } from '../../context';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { searchReactTranslationRef } from '../../translation';
 
@@ -56,9 +59,14 @@ export type SearchBarBaseProps = Omit<TextFieldProps, 'onChange'> & {
 };
 
 /**
- * All search boxes exported by the search plugin are based on the <SearchBarBase />,
- * and this one is based on the <InputBase /> component from Material UI.
- * Recommended if you don't use Search Provider or Search Context.
+ * Pure presentational search input used by all search boxes exported by
+ * the search plugin. Owns the debounced text state and Backstage's default
+ * input chrome (icon, clear button), but is intentionally decoupled from
+ * the SearchContext: callers supply `value` / `onChange` themselves.
+ *
+ * Use this directly when you maintain your own state (see `HomePageSearchBar`
+ * for an example), or compose it with {@link SearchBar} (a Decorator that
+ * adds SearchContext wiring + analytics) when context wiring is needed.
  *
  * @public
  */
@@ -170,31 +178,29 @@ export const SearchBarBase = forwardRef((props: SearchBarBaseProps, ref) => {
   );
 
   return (
-    <SearchContextProvider inheritParentContextIfAvailable>
-      <TextField
-        id="search-bar-text-field"
-        data-testid="search-bar-next"
-        variant="outlined"
-        margin="normal"
-        inputRef={ref}
-        value={value}
-        label={label}
-        placeholder={inputPlaceholder}
-        InputProps={{
-          startAdornment,
-          endAdornment: clearButton ? clearButtonEndAdornment : endAdornment,
-          ...InputProps,
-        }}
-        inputProps={{
-          'aria-label': ariaLabel,
-          ...inputProps,
-        }}
-        fullWidth={fullWidth}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        {...rest}
-      />
-    </SearchContextProvider>
+    <TextField
+      id="search-bar-text-field"
+      data-testid="search-bar-next"
+      variant="outlined"
+      margin="normal"
+      inputRef={ref}
+      value={value}
+      label={label}
+      placeholder={inputPlaceholder}
+      InputProps={{
+        startAdornment,
+        endAdornment: clearButton ? clearButtonEndAdornment : endAdornment,
+        ...InputProps,
+      }}
+      inputProps={{
+        'aria-label': ariaLabel,
+        ...inputProps,
+      }}
+      fullWidth={fullWidth}
+      onChange={handleChange}
+      onKeyDown={handleKeyDown}
+      {...rest}
+    />
   );
 });
 
@@ -205,45 +211,59 @@ export const SearchBarBase = forwardRef((props: SearchBarBaseProps, ref) => {
  */
 export type SearchBarProps = Partial<SearchBarBaseProps>;
 
+type SearchBarBaseComponent = ForwardRefExoticComponent<
+  PropsWithoutRef<SearchBarBaseProps> & RefAttributes<unknown>
+>;
+
 /**
- * Recommended search bar when you use the Search Provider or Search Context.
+ * Decorator (higher-order component) that wires a SearchBarBase-shaped
+ * component to the surrounding {@link SearchContextProvider} and adds
+ * analytics context. Reads `term` from context, bridges it to the wrapped
+ * component's `value` / `onChange`, and supports an optional `value`
+ * prop to seed the term on mount.
  *
- * @public
+ * Kept package-internal: consumers compose via {@link SearchBar} or
+ * by writing their own decorator in user code.
  */
-export const SearchBar = forwardRef((props: SearchBarProps, ref) => {
-  const { value: initialValue = '', onChange, ...rest } = props;
+const withSearchContext = (Component: SearchBarBaseComponent) =>
+  forwardRef<unknown, SearchBarProps>((props, ref) => {
+    const { value: initialValue = '', onChange, ...rest } = props;
 
-  const { term, setTerm } = useSearch();
+    const { term, setTerm } = useSearch();
 
-  useEffect(() => {
-    if (initialValue) {
-      setTerm(String(initialValue));
-    }
-  }, [initialValue, setTerm]);
-
-  const handleChange = useCallback(
-    (newValue: string) => {
-      if (onChange) {
-        onChange(newValue);
-      } else {
-        setTerm(newValue);
+    useEffect(() => {
+      if (initialValue) {
+        setTerm(String(initialValue));
       }
-    },
-    [onChange, setTerm],
-  );
+    }, [initialValue, setTerm]);
 
-  return (
-    <SearchContextProvider inheritParentContextIfAvailable>
+    const handleChange = useCallback(
+      (newValue: string) => {
+        if (onChange) {
+          onChange(newValue);
+        } else {
+          setTerm(newValue);
+        }
+      },
+      [onChange, setTerm],
+    );
+
+    return (
       <AnalyticsContext
         attributes={{ pluginId: 'search', extension: 'SearchBar' }}
       >
-        <SearchBarBase
-          {...rest}
-          ref={ref}
-          value={term}
-          onChange={handleChange}
-        />
+        <Component {...rest} ref={ref} value={term} onChange={handleChange} />
       </AnalyticsContext>
-    </SearchContextProvider>
-  );
-});
+    );
+  });
+
+/**
+ * SearchBar is {@link SearchBarBase} decorated with SearchContext wiring
+ * and analytics. Use this when your subtree is wrapped in a
+ * {@link SearchContextProvider}: the bar reads `term` from context and
+ * writes back to it on change. For standalone use without the search
+ * context, use {@link SearchBarBase} directly with your own state.
+ *
+ * @public
+ */
+export const SearchBar = withSearchContext(SearchBarBase);

--- a/plugins/search-react/src/components/SearchResult/SearchResult.tsx
+++ b/plugins/search-react/src/components/SearchResult/SearchResult.tsx
@@ -18,11 +18,7 @@ import { ReactNode } from 'react';
 import useAsync, { AsyncState } from 'react-use/esm/useAsync';
 import { isFunction } from 'lodash';
 
-import {
-  Progress,
-  EmptyState,
-  ResponseErrorPanel,
-} from '@backstage/core-components';
+import { EmptyState } from '@backstage/core-components';
 import { useApi, AnalyticsContext } from '@backstage/core-plugin-api';
 import { SearchQuery, SearchResultSet } from '@backstage/plugin-search-common';
 
@@ -32,6 +28,7 @@ import {
   SearchResultListItemExtensions,
   SearchResultListItemExtensionsProps,
 } from '../../extensions';
+import { SearchResultStateBoundary } from '../SearchResultStateBoundary';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { searchReactTranslationRef } from '../../translation';
 
@@ -198,36 +195,29 @@ export const SearchResultComponent = (props: SearchResultProps) => {
     ...rest
   } = props;
 
+  const renderSuccessContent = (value: SearchResultSet | undefined) => {
+    if (isFunction(children)) {
+      return value ? children(value) : null;
+    }
+    return (
+      <SearchResultListItemExtensions {...rest} results={value?.results ?? []}>
+        {children}
+      </SearchResultListItemExtensions>
+    );
+  };
+
   return (
     <SearchResultState query={query}>
-      {({ loading, error, value }) => {
-        if (loading) {
-          return <Progress />;
-        }
-
-        if (error) {
-          return (
-            <ResponseErrorPanel
-              title="Error encountered while fetching search results"
-              error={error}
-            />
-          );
-        }
-
-        if (!value?.results.length) {
-          return noResultsComponent;
-        }
-
-        if (isFunction(children)) {
-          return children(value);
-        }
-
-        return (
-          <SearchResultListItemExtensions {...rest} results={value.results}>
-            {children}
-          </SearchResultListItemExtensions>
-        );
-      }}
+      {({ loading, error, value }) => (
+        <SearchResultStateBoundary
+          loading={loading}
+          error={error}
+          isEmpty={!value?.results.length}
+          noResultsComponent={noResultsComponent}
+        >
+          {renderSuccessContent(value)}
+        </SearchResultStateBoundary>
+      )}
     </SearchResultState>
   );
 };

--- a/plugins/search-react/src/components/SearchResultList/SearchResultList.tsx
+++ b/plugins/search-react/src/components/SearchResultList/SearchResultList.tsx
@@ -18,11 +18,7 @@ import { ReactNode } from 'react';
 
 import List, { ListProps } from '@material-ui/core/List';
 
-import {
-  Progress,
-  EmptyState,
-  ResponseErrorPanel,
-} from '@backstage/core-components';
+import { EmptyState } from '@backstage/core-components';
 import { AnalyticsContext } from '@backstage/core-plugin-api';
 import { SearchResult } from '@backstage/plugin-search-common';
 
@@ -30,6 +26,7 @@ import { useSearchResultListItemExtensions } from '../../extensions';
 
 import { DefaultResultListItem } from '../DefaultResultListItem';
 import { SearchResultState, SearchResultStateProps } from '../SearchResult';
+import { SearchResultStateBoundary } from '../SearchResultStateBoundary';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { searchReactTranslationRef } from '../../translation';
 
@@ -92,24 +89,16 @@ export const SearchResultListLayout = (props: SearchResultListLayoutProps) => {
     ...rest
   } = props;
 
-  if (loading) {
-    return <Progress />;
-  }
-
-  if (error) {
-    return (
-      <ResponseErrorPanel
-        title="Error encountered while fetching search results"
-        error={error}
-      />
-    );
-  }
-
-  if (!resultItems?.length) {
-    return <>{noResultsComponent}</>;
-  }
-
-  return <List {...rest}>{resultItems.map(renderResultItem)}</List>;
+  return (
+    <SearchResultStateBoundary
+      loading={loading}
+      error={error}
+      isEmpty={!resultItems?.length}
+      noResultsComponent={noResultsComponent}
+    >
+      <List {...rest}>{(resultItems ?? []).map(renderResultItem)}</List>
+    </SearchResultStateBoundary>
+  );
 };
 
 /**

--- a/plugins/search-react/src/components/SearchResultStateBoundary/SearchResultStateBoundary.test.tsx
+++ b/plugins/search-react/src/components/SearchResultStateBoundary/SearchResultStateBoundary.test.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderInTestApp } from '@backstage/test-utils';
+
+import { SearchResultStateBoundary } from './SearchResultStateBoundary';
+
+describe('SearchResultStateBoundary', () => {
+  it('renders a progress indicator while loading', async () => {
+    const { getByTestId } = await renderInTestApp(
+      <SearchResultStateBoundary loading>
+        <span>content</span>
+      </SearchResultStateBoundary>,
+    );
+
+    expect(getByTestId('progress')).toBeInTheDocument();
+  });
+
+  it('renders the response error panel when an error is provided', async () => {
+    const error = new Error('boom');
+    const { getByRole } = await renderInTestApp(
+      <SearchResultStateBoundary error={error}>
+        <span>content</span>
+      </SearchResultStateBoundary>,
+    );
+
+    expect(getByRole('alert')).toHaveTextContent(
+      /Error encountered while fetching search results.*boom/,
+    );
+  });
+
+  it('renders the provided no-results component when empty', async () => {
+    const { getByText, queryByText } = await renderInTestApp(
+      <SearchResultStateBoundary isEmpty noResultsComponent={<>nothing here</>}>
+        <span>content</span>
+      </SearchResultStateBoundary>,
+    );
+
+    expect(getByText('nothing here')).toBeInTheDocument();
+    expect(queryByText('content')).toBeNull();
+  });
+
+  it('renders nothing in the empty case when noResultsComponent is null', async () => {
+    const { queryByText } = await renderInTestApp(
+      <SearchResultStateBoundary isEmpty noResultsComponent={null}>
+        <span>content</span>
+      </SearchResultStateBoundary>,
+    );
+
+    expect(queryByText('content')).toBeNull();
+  });
+
+  it('renders children in the loaded, error-free, non-empty case', async () => {
+    const { getByText } = await renderInTestApp(
+      <SearchResultStateBoundary>
+        <span>content</span>
+      </SearchResultStateBoundary>,
+    );
+
+    expect(getByText('content')).toBeInTheDocument();
+  });
+
+  it('prioritizes loading over error and empty', async () => {
+    const { getByTestId, queryByRole, queryByText } = await renderInTestApp(
+      <SearchResultStateBoundary
+        loading
+        error={new Error('boom')}
+        isEmpty
+        noResultsComponent={<>nothing here</>}
+      >
+        <span>content</span>
+      </SearchResultStateBoundary>,
+    );
+
+    expect(getByTestId('progress')).toBeInTheDocument();
+    expect(queryByRole('alert')).toBeNull();
+    expect(queryByText('nothing here')).toBeNull();
+    expect(queryByText('content')).toBeNull();
+  });
+});

--- a/plugins/search-react/src/components/SearchResultStateBoundary/SearchResultStateBoundary.tsx
+++ b/plugins/search-react/src/components/SearchResultStateBoundary/SearchResultStateBoundary.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactNode } from 'react';
+
+import { Progress, ResponseErrorPanel } from '@backstage/core-components';
+
+/**
+ * Props for {@link SearchResultStateBoundary}.
+ */
+export type SearchResultStateBoundaryProps = {
+  /**
+   * Whether the result set is still loading. Renders a default {@link Progress} indicator.
+   */
+  loading?: boolean;
+  /**
+   * Error from the result fetch. Renders a default {@link ResponseErrorPanel}.
+   */
+  error?: Error;
+  /**
+   * Whether the result set is empty. Renders {@link SearchResultStateBoundaryProps.noResultsComponent}.
+   */
+  isEmpty?: boolean;
+  /**
+   * Node rendered for the empty case. Pass `null` to suppress empty rendering.
+   */
+  noResultsComponent?: ReactNode;
+  /**
+   * Content rendered when the result is loaded, error-free, and non-empty.
+   */
+  children: ReactNode;
+};
+
+/**
+ * Internal facade that consolidates the loading / error / empty rendering
+ * for search result components. Centralizing these UX choices (Progress,
+ * ResponseErrorPanel, empty-state slot) keeps the surrounding components
+ * focused on success rendering and avoids drift in copy or behavior across
+ * result surfaces.
+ *
+ * Branch precedence: loading > error > empty > children.
+ */
+export const SearchResultStateBoundary = (
+  props: SearchResultStateBoundaryProps,
+) => {
+  const { loading, error, isEmpty, noResultsComponent, children } = props;
+
+  if (loading) {
+    return <Progress />;
+  }
+
+  if (error) {
+    return (
+      <ResponseErrorPanel
+        title="Error encountered while fetching search results"
+        error={error}
+      />
+    );
+  }
+
+  if (isEmpty) {
+    return <>{noResultsComponent}</>;
+  }
+
+  return <>{children}</>;
+};

--- a/plugins/search-react/src/components/SearchResultStateBoundary/index.tsx
+++ b/plugins/search-react/src/components/SearchResultStateBoundary/index.tsx
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { SearchResultStateBoundary } from './SearchResultStateBoundary';
+export type { SearchResultStateBoundaryProps } from './SearchResultStateBoundary';


### PR DESCRIPTION
Closes #51

## Summary

- **Problem:** Timeout-wrapped `fetch` (AbortController + setTimeout + clearTimeout) was implemented twice — once in `plugin.ts` (production OIDC discovery proxy) and once in `plugin.test.ts` — with near-identical semantics. This duplicated low-level HTTP cancellation behavior and risked drift between production and test paths.
- **Approach:** Introduced a small **Adapter** utility, `services/fetchWithTimeout`, that owns the abort/timer lifecycle behind one interface. Migrated both call sites to use it. The test file keeps a thin closure (`fetchWithTestTimeout`) that delegates to the shared adapter with the test-specific timeout, preserving call-site readability.
- **Behavior:** Unchanged. Same `signal: controller.signal` semantics, same default timeouts (10s prod, 2s test), same `RequestInit` passthrough.

## Design pattern

- **Pattern:** Adapter (Structural)
- **Rationale:** Wraps the global `fetch` API behind a normalized interface that turns a `timeoutMs` into a managed `AbortController` + cleared timer. Callers no longer touch `AbortController` directly; they just hand the adapter their existing `RequestInit` plus a timeout.

### Before / after responsibility map

- **Before:** Each caller owned: build controller → schedule setTimeout → call fetch with controller's signal → clear timer in finally. Two copies of this logic in two files.
- **After:** `fetchWithTimeout(url, { timeoutMs, ...init })` owns all four concerns. `plugin.ts` and `plugin.test.ts` only own their domain (URL building, response handling, mocking).

## Files changed

- `plugins/mcp-actions-backend/src/services/fetchWithTimeout.ts` *(new — adapter)*
- `plugins/mcp-actions-backend/src/services/fetchWithTimeout.test.ts` *(new — pins timeout/abort contract)*
- `plugins/mcp-actions-backend/src/plugin.ts` *(removed local helper; uses adapter with `timeoutMs: 10_000`)*
- `plugins/mcp-actions-backend/src/plugin.test.ts` *(removed duplicate helper; thin `fetchWithTestTimeout` delegates to adapter with `timeoutMs: 2_000`)*

## Verification

- `yarn workspace @backstage/plugin-mcp-actions-backend lint` — clean
- `yarn workspace @backstage/plugin-mcp-actions-backend test` — **47/47 tests pass across 8 suites**, including:
  - OIDC discovery success: `registers /.well-known/oauth-authorization-server when dynamic client registration is enabled`
  - OIDC discovery failure: `should return 502 when OIDC discovery fetch fails`
  - Session-id 400s on the SSE messages route (which previously used the duplicated test helper)
  - All MCP streamable/SSE/`tools/call` tests
- New unit tests on the adapter explicitly cover:
  - Forwarding URL + `init` and supplying an `AbortSignal`
  - Aborting on timeout
  - Clearing the timer on success (no late abort)
  - Clearing the timer when `fetch` rejects

## Evidence of improvement

- **Single source of truth:** Cancellation/timeout logic now lives in one file. Future changes (e.g. tweaking the abort reason or adding telemetry) land in one place instead of two.
- **Reduced drift risk:** Production and test paths share the same controller + cleanup semantics by construction.
- **Cleaner domain code:** `plugin.ts` no longer has 12 lines of HTTP plumbing; `plugin.test.ts` no longer has 15. Both files now read as domain logic.
- **Type-level guidance:** `Omit<RequestInit, 'signal'>` on the adapter's options makes it explicit that the adapter owns cancellation; callers can't accidentally clobber it.

## Non-goals

- No broad HTTP client replacement (still uses global `fetch`).
- No retry / backoff feature introduced.
- No change to endpoint behavior or response handling semantics.
- No public API surface changes; the adapter is internal to the plugin (`src/services/fetchWithTimeout.ts`).

## Reviewer checklist

- [ ] `services/fetchWithTimeout.ts` is the single implementation of timeout-fetch in the plugin.
- [ ] `plugin.ts` no longer defines a local `fetchWithTimeout`; it imports the adapter and passes `{ timeoutMs: 10_000 }` (matches previous default).
- [ ] `plugin.test.ts` no longer defines a local `fetchWithTimeout`; the test-side helper `fetchWithTestTimeout(url, init)` delegates to the adapter with `{ timeoutMs: 2_000 }` and forwards `RequestInit`.
- [ ] The OIDC discovery production path still applies a 10-second timeout via `AbortController.signal` and clears the timer on both success and failure paths.
- [ ] Existing OIDC success / 502 failure tests pass; their fetch spies still observe `/.well-known/openid-configuration` calls.
- [ ] Session-id 400 tests on the SSE messages route still pass (formerly using the duplicated helper).
- [ ] New `fetchWithTimeout.test.ts` covers: forwards URL/init + signal; aborts on timeout; clears timer on success; clears timer on rejection.
- [ ] No public API surface change; adapter is plugin-internal under `src/services/`.
- [ ] No retry/backoff or HTTP-client-replacement scope creep.
- [ ] `yarn workspace @backstage/plugin-mcp-actions-backend lint` passes.
- [ ] `yarn workspace @backstage/plugin-mcp-actions-backend test` passes (47/47 across 8 suites).