### PR TITLE
P3/issue 53 extension match strategy registry

### DIFF
--- a/plugins/mcp-actions-backend/src/plugin.test.ts
+++ b/plugins/mcp-actions-backend/src/plugin.test.ts
@@ -15,6 +15,7 @@
  */
 import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
 import { mcpPlugin } from './plugin';
+import { fetchWithTimeout } from './services/fetchWithTimeout';
 import { actionsRegistryServiceRef } from '@backstage/backend-plugin-api/alpha';
 import { createBackendPlugin } from '@backstage/backend-plugin-api';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -141,22 +142,8 @@ describe('Mcp Backend', () => {
     };
   };
 
-  const fetchWithTimeout = async (
-    url: string,
-    init?: RequestInit,
-  ): Promise<Response> => {
-    const controller = new AbortController();
-    const timeoutHandle = setTimeout(() => controller.abort(), 2_000);
-
-    try {
-      return await fetch(url, {
-        ...init,
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timeoutHandle);
-    }
-  };
+  const fetchWithTestTimeout = (url: string, init?: RequestInit) =>
+    fetchWithTimeout(url, { ...init, timeoutMs: 2_000 });
 
   it('should support streamable spec', async () => {
     const { client, serverAddress } = await getContext();
@@ -230,7 +217,7 @@ describe('Mcp Backend', () => {
   it('returns completed 400 response when sessionId is missing', async () => {
     const { serverAddress } = await getContext();
 
-    const response = await fetchWithTimeout(
+    const response = await fetchWithTestTimeout(
       `${serverAddress}/api/mcp-actions/v1/sse/messages`,
       { method: 'POST' },
     );
@@ -243,7 +230,7 @@ describe('Mcp Backend', () => {
     const { serverAddress } = await getContext();
     const sessionId = 'unknown-session-id';
 
-    const response = await fetchWithTimeout(
+    const response = await fetchWithTestTimeout(
       `${serverAddress}/api/mcp-actions/v1/sse/messages?sessionId=${sessionId}`,
       { method: 'POST' },
     );

--- a/plugins/mcp-actions-backend/src/plugin.ts
+++ b/plugins/mcp-actions-backend/src/plugin.ts
@@ -26,26 +26,13 @@ import {
 import { json } from 'express';
 import Router from 'express-promise-router';
 import { McpService } from './services/McpService';
+import { fetchWithTimeout } from './services/fetchWithTimeout';
 import { createStreamableRouter } from './routers/createStreamableRouter';
 import { createSseRouter } from './routers/createSseRouter';
 import {
   actionsRegistryServiceRef,
   actionsServiceRef,
 } from '@backstage/backend-plugin-api/alpha';
-
-async function fetchWithTimeout(
-  url: string,
-  timeoutMs: number,
-): Promise<Response> {
-  const controller = new AbortController();
-  const timeoutHandle = setTimeout(() => controller.abort(), timeoutMs);
-
-  try {
-    return await fetch(url, { signal: controller.signal });
-  } finally {
-    clearTimeout(timeoutHandle);
-  }
-}
 
 function toSafeHttpUrl(urlRaw: string): URL | undefined {
   try {
@@ -127,10 +114,9 @@ function registerOidcDiscoveryRouteIfEnabled(options: {
         authBaseUrl,
       ).toString();
 
-      const oidcResponse = await fetchWithTimeout(
-        openIdConfigurationUrl,
-        10_000,
-      );
+      const oidcResponse = await fetchWithTimeout(openIdConfigurationUrl, {
+        timeoutMs: 10_000,
+      });
 
       if (!oidcResponse.ok) {
         logger.error(oidcDiscoveryErrorMessage, {

--- a/plugins/mcp-actions-backend/src/services/fetchWithTimeout.test.ts
+++ b/plugins/mcp-actions-backend/src/services/fetchWithTimeout.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fetchWithTimeout } from './fetchWithTimeout';
+
+describe('fetchWithTimeout', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('forwards url and init to fetch and supplies an AbortSignal', async () => {
+    const fetchSpy = jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue({ ok: true } as Response);
+
+    const response = await fetchWithTimeout('http://example.test/api', {
+      method: 'POST',
+      timeoutMs: 1_000,
+    });
+
+    expect(response.ok).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    const [calledUrl, calledInit] = fetchSpy.mock.calls[0];
+    expect(calledUrl).toBe('http://example.test/api');
+    expect(calledInit).toEqual(
+      expect.objectContaining({
+        method: 'POST',
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect((calledInit as RequestInit).signal?.aborted).toBe(false);
+  });
+
+  it('aborts the request when the timeout elapses', async () => {
+    jest.useFakeTimers();
+
+    let capturedSignal: AbortSignal | undefined;
+    jest.spyOn(globalThis, 'fetch').mockImplementation(
+      (_input, init) =>
+        new Promise<Response>((_, reject) => {
+          capturedSignal =
+            (init as RequestInit | undefined)?.signal ?? undefined;
+          capturedSignal?.addEventListener('abort', () => {
+            reject(new DOMException('aborted', 'AbortError'));
+          });
+        }),
+    );
+
+    const pending = fetchWithTimeout('http://example.test/api', {
+      timeoutMs: 50,
+    });
+
+    jest.advanceTimersByTime(50);
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(capturedSignal?.aborted).toBe(true);
+  });
+
+  it('clears the timer on a successful response so it does not abort later', async () => {
+    jest.useFakeTimers();
+
+    let capturedSignal: AbortSignal | undefined;
+    const okResponse = { ok: true } as Response;
+    jest.spyOn(globalThis, 'fetch').mockImplementation(async (_input, init) => {
+      capturedSignal = (init as RequestInit | undefined)?.signal ?? undefined;
+      return okResponse;
+    });
+
+    await fetchWithTimeout('http://example.test/api', { timeoutMs: 1_000 });
+
+    jest.advanceTimersByTime(5_000);
+
+    expect(capturedSignal?.aborted).toBe(false);
+  });
+
+  it('clears the timer when fetch rejects', async () => {
+    jest.useFakeTimers();
+
+    let capturedSignal: AbortSignal | undefined;
+    jest.spyOn(globalThis, 'fetch').mockImplementation(async (_input, init) => {
+      capturedSignal = (init as RequestInit | undefined)?.signal ?? undefined;
+      throw new Error('network down');
+    });
+
+    await expect(
+      fetchWithTimeout('http://example.test/api', { timeoutMs: 1_000 }),
+    ).rejects.toThrow('network down');
+
+    jest.advanceTimersByTime(5_000);
+
+    expect(capturedSignal?.aborted).toBe(false);
+  });
+});

--- a/plugins/mcp-actions-backend/src/services/fetchWithTimeout.ts
+++ b/plugins/mcp-actions-backend/src/services/fetchWithTimeout.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Options accepted by {@link fetchWithTimeout}.
+ *
+ * Mirrors {@link RequestInit} but excludes `signal` because the adapter owns
+ * the abort signal driving the timeout. Adds a `timeoutMs` knob for the
+ * call-site timeout, defaulting to 10s.
+ */
+export type FetchWithTimeoutOptions = Omit<RequestInit, 'signal'> & {
+  /**
+   * Time in milliseconds before the request is aborted. Defaults to 10_000.
+   */
+  timeoutMs?: number;
+};
+
+/**
+ * Adapter that normalizes timeout-aware fetch behavior behind a single
+ * interface. Wires an {@link AbortController} to a `setTimeout`, forwards any
+ * caller-provided {@link RequestInit} fields, and ensures the timer is cleared
+ * on both success and failure paths.
+ *
+ * Replaces the previously duplicated `fetchWithTimeout` helpers in the plugin
+ * route logic and the plugin tests, eliminating drift risk between
+ * production and test cancellation behavior.
+ */
+export async function fetchWithTimeout(
+  url: string,
+  options: FetchWithTimeoutOptions = {},
+): Promise<Response> {
+  const { timeoutMs = 10_000, ...init } = options;
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+}

--- a/plugins/search-react/src/components/SearchBar/SearchBar.tsx
+++ b/plugins/search-react/src/components/SearchBar/SearchBar.tsx
@@ -27,17 +27,20 @@ import Button from '@material-ui/core/Button';
 import { TextFieldProps } from '@material-ui/core/TextField';
 import DefaultSearchIcon from '@material-ui/icons/Search';
 import {
-  ReactNode,
   ChangeEvent,
-  forwardRef,
+  ForwardRefExoticComponent,
   KeyboardEvent,
+  PropsWithoutRef,
+  ReactNode,
+  RefAttributes,
+  forwardRef,
   useCallback,
   useEffect,
   useRef,
   useState,
 } from 'react';
 import useDebounce from 'react-use/esm/useDebounce';
-import { SearchContextProvider, useSearch } from '../../context';
+import { useSearch } from '../../context';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { searchReactTranslationRef } from '../../translation';
 
@@ -56,9 +59,14 @@ export type SearchBarBaseProps = Omit<TextFieldProps, 'onChange'> & {
 };
 
 /**
- * All search boxes exported by the search plugin are based on the <SearchBarBase />,
- * and this one is based on the <InputBase /> component from Material UI.
- * Recommended if you don't use Search Provider or Search Context.
+ * Pure presentational search input used by all search boxes exported by
+ * the search plugin. Owns the debounced text state and Backstage's default
+ * input chrome (icon, clear button), but is intentionally decoupled from
+ * the SearchContext: callers supply `value` / `onChange` themselves.
+ *
+ * Use this directly when you maintain your own state (see `HomePageSearchBar`
+ * for an example), or compose it with {@link SearchBar} (a Decorator that
+ * adds SearchContext wiring + analytics) when context wiring is needed.
  *
  * @public
  */
@@ -170,31 +178,29 @@ export const SearchBarBase = forwardRef((props: SearchBarBaseProps, ref) => {
   );
 
   return (
-    <SearchContextProvider inheritParentContextIfAvailable>
-      <TextField
-        id="search-bar-text-field"
-        data-testid="search-bar-next"
-        variant="outlined"
-        margin="normal"
-        inputRef={ref}
-        value={value}
-        label={label}
-        placeholder={inputPlaceholder}
-        InputProps={{
-          startAdornment,
-          endAdornment: clearButton ? clearButtonEndAdornment : endAdornment,
-          ...InputProps,
-        }}
-        inputProps={{
-          'aria-label': ariaLabel,
-          ...inputProps,
-        }}
-        fullWidth={fullWidth}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        {...rest}
-      />
-    </SearchContextProvider>
+    <TextField
+      id="search-bar-text-field"
+      data-testid="search-bar-next"
+      variant="outlined"
+      margin="normal"
+      inputRef={ref}
+      value={value}
+      label={label}
+      placeholder={inputPlaceholder}
+      InputProps={{
+        startAdornment,
+        endAdornment: clearButton ? clearButtonEndAdornment : endAdornment,
+        ...InputProps,
+      }}
+      inputProps={{
+        'aria-label': ariaLabel,
+        ...inputProps,
+      }}
+      fullWidth={fullWidth}
+      onChange={handleChange}
+      onKeyDown={handleKeyDown}
+      {...rest}
+    />
   );
 });
 
@@ -205,45 +211,59 @@ export const SearchBarBase = forwardRef((props: SearchBarBaseProps, ref) => {
  */
 export type SearchBarProps = Partial<SearchBarBaseProps>;
 
+type SearchBarBaseComponent = ForwardRefExoticComponent<
+  PropsWithoutRef<SearchBarBaseProps> & RefAttributes<unknown>
+>;
+
 /**
- * Recommended search bar when you use the Search Provider or Search Context.
+ * Decorator (higher-order component) that wires a SearchBarBase-shaped
+ * component to the surrounding {@link SearchContextProvider} and adds
+ * analytics context. Reads `term` from context, bridges it to the wrapped
+ * component's `value` / `onChange`, and supports an optional `value`
+ * prop to seed the term on mount.
  *
- * @public
+ * Kept package-internal: consumers compose via {@link SearchBar} or
+ * by writing their own decorator in user code.
  */
-export const SearchBar = forwardRef((props: SearchBarProps, ref) => {
-  const { value: initialValue = '', onChange, ...rest } = props;
+const withSearchContext = (Component: SearchBarBaseComponent) =>
+  forwardRef<unknown, SearchBarProps>((props, ref) => {
+    const { value: initialValue = '', onChange, ...rest } = props;
 
-  const { term, setTerm } = useSearch();
+    const { term, setTerm } = useSearch();
 
-  useEffect(() => {
-    if (initialValue) {
-      setTerm(String(initialValue));
-    }
-  }, [initialValue, setTerm]);
-
-  const handleChange = useCallback(
-    (newValue: string) => {
-      if (onChange) {
-        onChange(newValue);
-      } else {
-        setTerm(newValue);
+    useEffect(() => {
+      if (initialValue) {
+        setTerm(String(initialValue));
       }
-    },
-    [onChange, setTerm],
-  );
+    }, [initialValue, setTerm]);
 
-  return (
-    <SearchContextProvider inheritParentContextIfAvailable>
+    const handleChange = useCallback(
+      (newValue: string) => {
+        if (onChange) {
+          onChange(newValue);
+        } else {
+          setTerm(newValue);
+        }
+      },
+      [onChange, setTerm],
+    );
+
+    return (
       <AnalyticsContext
         attributes={{ pluginId: 'search', extension: 'SearchBar' }}
       >
-        <SearchBarBase
-          {...rest}
-          ref={ref}
-          value={term}
-          onChange={handleChange}
-        />
+        <Component {...rest} ref={ref} value={term} onChange={handleChange} />
       </AnalyticsContext>
-    </SearchContextProvider>
-  );
-});
+    );
+  });
+
+/**
+ * SearchBar is {@link SearchBarBase} decorated with SearchContext wiring
+ * and analytics. Use this when your subtree is wrapped in a
+ * {@link SearchContextProvider}: the bar reads `term` from context and
+ * writes back to it on change. For standalone use without the search
+ * context, use {@link SearchBarBase} directly with your own state.
+ *
+ * @public
+ */
+export const SearchBar = withSearchContext(SearchBarBase);

--- a/plugins/search-react/src/components/SearchResult/SearchResult.tsx
+++ b/plugins/search-react/src/components/SearchResult/SearchResult.tsx
@@ -18,11 +18,7 @@ import { ReactNode } from 'react';
 import useAsync, { AsyncState } from 'react-use/esm/useAsync';
 import { isFunction } from 'lodash';
 
-import {
-  Progress,
-  EmptyState,
-  ResponseErrorPanel,
-} from '@backstage/core-components';
+import { EmptyState } from '@backstage/core-components';
 import { useApi, AnalyticsContext } from '@backstage/core-plugin-api';
 import { SearchQuery, SearchResultSet } from '@backstage/plugin-search-common';
 
@@ -32,6 +28,7 @@ import {
   SearchResultListItemExtensions,
   SearchResultListItemExtensionsProps,
 } from '../../extensions';
+import { SearchResultStateBoundary } from '../SearchResultStateBoundary';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { searchReactTranslationRef } from '../../translation';
 
@@ -198,36 +195,29 @@ export const SearchResultComponent = (props: SearchResultProps) => {
     ...rest
   } = props;
 
+  const renderSuccessContent = (value: SearchResultSet | undefined) => {
+    if (isFunction(children)) {
+      return value ? children(value) : null;
+    }
+    return (
+      <SearchResultListItemExtensions {...rest} results={value?.results ?? []}>
+        {children}
+      </SearchResultListItemExtensions>
+    );
+  };
+
   return (
     <SearchResultState query={query}>
-      {({ loading, error, value }) => {
-        if (loading) {
-          return <Progress />;
-        }
-
-        if (error) {
-          return (
-            <ResponseErrorPanel
-              title="Error encountered while fetching search results"
-              error={error}
-            />
-          );
-        }
-
-        if (!value?.results.length) {
-          return noResultsComponent;
-        }
-
-        if (isFunction(children)) {
-          return children(value);
-        }
-
-        return (
-          <SearchResultListItemExtensions {...rest} results={value.results}>
-            {children}
-          </SearchResultListItemExtensions>
-        );
-      }}
+      {({ loading, error, value }) => (
+        <SearchResultStateBoundary
+          loading={loading}
+          error={error}
+          isEmpty={!value?.results.length}
+          noResultsComponent={noResultsComponent}
+        >
+          {renderSuccessContent(value)}
+        </SearchResultStateBoundary>
+      )}
     </SearchResultState>
   );
 };

--- a/plugins/search-react/src/components/SearchResultList/SearchResultList.tsx
+++ b/plugins/search-react/src/components/SearchResultList/SearchResultList.tsx
@@ -18,11 +18,7 @@ import { ReactNode } from 'react';
 
 import List, { ListProps } from '@material-ui/core/List';
 
-import {
-  Progress,
-  EmptyState,
-  ResponseErrorPanel,
-} from '@backstage/core-components';
+import { EmptyState } from '@backstage/core-components';
 import { AnalyticsContext } from '@backstage/core-plugin-api';
 import { SearchResult } from '@backstage/plugin-search-common';
 
@@ -30,6 +26,7 @@ import { useSearchResultListItemExtensions } from '../../extensions';
 
 import { DefaultResultListItem } from '../DefaultResultListItem';
 import { SearchResultState, SearchResultStateProps } from '../SearchResult';
+import { SearchResultStateBoundary } from '../SearchResultStateBoundary';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { searchReactTranslationRef } from '../../translation';
 
@@ -92,24 +89,16 @@ export const SearchResultListLayout = (props: SearchResultListLayoutProps) => {
     ...rest
   } = props;
 
-  if (loading) {
-    return <Progress />;
-  }
-
-  if (error) {
-    return (
-      <ResponseErrorPanel
-        title="Error encountered while fetching search results"
-        error={error}
-      />
-    );
-  }
-
-  if (!resultItems?.length) {
-    return <>{noResultsComponent}</>;
-  }
-
-  return <List {...rest}>{resultItems.map(renderResultItem)}</List>;
+  return (
+    <SearchResultStateBoundary
+      loading={loading}
+      error={error}
+      isEmpty={!resultItems?.length}
+      noResultsComponent={noResultsComponent}
+    >
+      <List {...rest}>{(resultItems ?? []).map(renderResultItem)}</List>
+    </SearchResultStateBoundary>
+  );
 };
 
 /**

--- a/plugins/search-react/src/components/SearchResultStateBoundary/SearchResultStateBoundary.test.tsx
+++ b/plugins/search-react/src/components/SearchResultStateBoundary/SearchResultStateBoundary.test.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderInTestApp } from '@backstage/test-utils';
+
+import { SearchResultStateBoundary } from './SearchResultStateBoundary';
+
+describe('SearchResultStateBoundary', () => {
+  it('renders a progress indicator while loading', async () => {
+    const { getByTestId } = await renderInTestApp(
+      <SearchResultStateBoundary loading>
+        <span>content</span>
+      </SearchResultStateBoundary>,
+    );
+
+    expect(getByTestId('progress')).toBeInTheDocument();
+  });
+
+  it('renders the response error panel when an error is provided', async () => {
+    const error = new Error('boom');
+    const { getByRole } = await renderInTestApp(
+      <SearchResultStateBoundary error={error}>
+        <span>content</span>
+      </SearchResultStateBoundary>,
+    );
+
+    expect(getByRole('alert')).toHaveTextContent(
+      /Error encountered while fetching search results.*boom/,
+    );
+  });
+
+  it('renders the provided no-results component when empty', async () => {
+    const { getByText, queryByText } = await renderInTestApp(
+      <SearchResultStateBoundary isEmpty noResultsComponent={<>nothing here</>}>
+        <span>content</span>
+      </SearchResultStateBoundary>,
+    );
+
+    expect(getByText('nothing here')).toBeInTheDocument();
+    expect(queryByText('content')).toBeNull();
+  });
+
+  it('renders nothing in the empty case when noResultsComponent is null', async () => {
+    const { queryByText } = await renderInTestApp(
+      <SearchResultStateBoundary isEmpty noResultsComponent={null}>
+        <span>content</span>
+      </SearchResultStateBoundary>,
+    );
+
+    expect(queryByText('content')).toBeNull();
+  });
+
+  it('renders children in the loaded, error-free, non-empty case', async () => {
+    const { getByText } = await renderInTestApp(
+      <SearchResultStateBoundary>
+        <span>content</span>
+      </SearchResultStateBoundary>,
+    );
+
+    expect(getByText('content')).toBeInTheDocument();
+  });
+
+  it('prioritizes loading over error and empty', async () => {
+    const { getByTestId, queryByRole, queryByText } = await renderInTestApp(
+      <SearchResultStateBoundary
+        loading
+        error={new Error('boom')}
+        isEmpty
+        noResultsComponent={<>nothing here</>}
+      >
+        <span>content</span>
+      </SearchResultStateBoundary>,
+    );
+
+    expect(getByTestId('progress')).toBeInTheDocument();
+    expect(queryByRole('alert')).toBeNull();
+    expect(queryByText('nothing here')).toBeNull();
+    expect(queryByText('content')).toBeNull();
+  });
+});

--- a/plugins/search-react/src/components/SearchResultStateBoundary/SearchResultStateBoundary.tsx
+++ b/plugins/search-react/src/components/SearchResultStateBoundary/SearchResultStateBoundary.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactNode } from 'react';
+
+import { Progress, ResponseErrorPanel } from '@backstage/core-components';
+
+/**
+ * Props for {@link SearchResultStateBoundary}.
+ */
+export type SearchResultStateBoundaryProps = {
+  /**
+   * Whether the result set is still loading. Renders a default {@link Progress} indicator.
+   */
+  loading?: boolean;
+  /**
+   * Error from the result fetch. Renders a default {@link ResponseErrorPanel}.
+   */
+  error?: Error;
+  /**
+   * Whether the result set is empty. Renders {@link SearchResultStateBoundaryProps.noResultsComponent}.
+   */
+  isEmpty?: boolean;
+  /**
+   * Node rendered for the empty case. Pass `null` to suppress empty rendering.
+   */
+  noResultsComponent?: ReactNode;
+  /**
+   * Content rendered when the result is loaded, error-free, and non-empty.
+   */
+  children: ReactNode;
+};
+
+/**
+ * Internal facade that consolidates the loading / error / empty rendering
+ * for search result components. Centralizing these UX choices (Progress,
+ * ResponseErrorPanel, empty-state slot) keeps the surrounding components
+ * focused on success rendering and avoids drift in copy or behavior across
+ * result surfaces.
+ *
+ * Branch precedence: loading > error > empty > children.
+ */
+export const SearchResultStateBoundary = (
+  props: SearchResultStateBoundaryProps,
+) => {
+  const { loading, error, isEmpty, noResultsComponent, children } = props;
+
+  if (loading) {
+    return <Progress />;
+  }
+
+  if (error) {
+    return (
+      <ResponseErrorPanel
+        title="Error encountered while fetching search results"
+        error={error}
+      />
+    );
+  }
+
+  if (isEmpty) {
+    return <>{noResultsComponent}</>;
+  }
+
+  return <>{children}</>;
+};

--- a/plugins/search-react/src/components/SearchResultStateBoundary/index.tsx
+++ b/plugins/search-react/src/components/SearchResultStateBoundary/index.tsx
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { SearchResultStateBoundary } from './SearchResultStateBoundary';
+export type { SearchResultStateBoundaryProps } from './SearchResultStateBoundary';

--- a/plugins/search-react/src/extensions.test.tsx
+++ b/plugins/search-react/src/extensions.test.tsx
@@ -192,4 +192,72 @@ describe('extensions', () => {
     expect(screen.getByText('Search Result 1')).toBeInTheDocument();
     expect(screen.getByText('Search Result 2')).toBeInTheDocument();
   });
+
+  it('falls back to the default list item when no predicate matches', async () => {
+    const plugin = createPlugin({ id: 'plugin' });
+    const ExploreSearchResultListItemExtension = createExtension(plugin, {
+      predicate: (result: SearchResult) => result.type === 'explore',
+      component: async () => (props: { result?: SearchDocument }) =>
+        (
+          <>
+            <ListItemText primary="Explore" secondary={props.result?.title} />
+          </>
+        ),
+    });
+
+    await renderInTestApp(
+      <TestApiProvider apis={[[analyticsApiRef, analyticsApiMock]]}>
+        <SearchResultListItemExtensions results={results}>
+          <ExploreSearchResultListItemExtension />
+        </SearchResultListItemExtensions>
+      </TestApiProvider>,
+    );
+
+    expect(screen.getAllByText('Explore')).toHaveLength(1);
+    expect(screen.queryByText('Default')).not.toBeInTheDocument();
+    expect(screen.getByText('Search Result 1')).toBeInTheDocument();
+    expect(
+      screen.getByText('Some text from the search result 2'),
+    ).toBeInTheDocument();
+  });
+
+  it('preserves precedence: first matching predicate wins over later predicates', async () => {
+    const plugin = createPlugin({ id: 'plugin' });
+    const PrimaryExploreExtension = createExtension(plugin, {
+      predicate: (result: SearchResult) => result.type === 'explore',
+      component: async () => (props: { result?: SearchDocument }) =>
+        (
+          <>
+            <ListItemText
+              primary="PrimaryExplore"
+              secondary={props.result?.title}
+            />
+          </>
+        ),
+    });
+    const SecondaryExploreExtension = createExtension(plugin, {
+      predicate: (result: SearchResult) => result.type === 'explore',
+      component: async () => (props: { result?: SearchDocument }) =>
+        (
+          <>
+            <ListItemText
+              primary="SecondaryExplore"
+              secondary={props.result?.title}
+            />
+          </>
+        ),
+    });
+
+    await renderInTestApp(
+      <TestApiProvider apis={[[analyticsApiRef, analyticsApiMock]]}>
+        <SearchResultListItemExtensions results={results}>
+          <PrimaryExploreExtension />
+          <SecondaryExploreExtension />
+        </SearchResultListItemExtensions>
+      </TestApiProvider>,
+    );
+
+    expect(screen.getAllByText('PrimaryExplore')).toHaveLength(1);
+    expect(screen.queryByText('SecondaryExplore')).not.toBeInTheDocument();
+  });
 });

--- a/plugins/search-react/src/extensions.tsx
+++ b/plugins/search-react/src/extensions.tsx
@@ -16,6 +16,7 @@
 
 import {
   Fragment,
+  ReactElement,
   ReactNode,
   PropsWithChildren,
   isValidElement,
@@ -44,34 +45,6 @@ import { DefaultResultListItem } from './components/DefaultResultListItem';
  */
 const SEARCH_RESULT_LIST_ITEM_EXTENSION =
   'search.results.list.items.extensions.v1';
-
-/**
- * @internal
- * Returns the first extension element found for a given result, and null otherwise.
- * @param elements - All extension elements.
- * @param result - The search result.
- */
-const findSearchResultListItemExtensionElement = (
-  elements: ReactNode[],
-  result: SearchResult,
-) => {
-  for (const element of elements) {
-    if (!isValidElement(element)) continue;
-    const predicate = getComponentData<(result: SearchResult) => boolean>(
-      element,
-      SEARCH_RESULT_LIST_ITEM_EXTENSION,
-    );
-    if (!predicate?.(result)) continue;
-    return cloneElement(element, {
-      rank: result.rank,
-      highlight: result.highlight,
-      result: result.document,
-      // Use props in situations where a consumer is manually rendering the extension
-      ...element.props,
-    });
-  }
-  return null;
-};
 
 /**
  * @public
@@ -183,6 +156,94 @@ export const createSearchResultListItemExtension = <
 };
 
 /**
+ * @internal
+ * One unit of the matching pipeline. A strategy attempts to produce a
+ * rendered element for a given search result. Returning `null` means the
+ * strategy abstains and the next strategy in the registry is tried.
+ *
+ * Strategies are evaluated in order of registration; the first non-null
+ * result wins. Replaces the previous ad hoc branching and makes the
+ * resolution precedence explicit and individually testable.
+ */
+type SearchResultListItemMatchStrategy = {
+  name: string;
+  match: (elements: ReactNode[], result: SearchResult) => ReactElement | null;
+};
+
+/**
+ * Primary strategy: render the first child extension whose registered
+ * predicate accepts the current result. Mirrors the previous behavior of
+ * the inline matcher inside `useSearchResultListItemExtensions`.
+ */
+const matchByRegisteredPredicate: SearchResultListItemMatchStrategy = {
+  name: 'predicate-match',
+  match: (elements, result) => {
+    for (const element of elements) {
+      if (!isValidElement(element)) continue;
+      const predicate = getComponentData<(r: SearchResult) => boolean>(
+        element,
+        SEARCH_RESULT_LIST_ITEM_EXTENSION,
+      );
+      if (!predicate?.(result)) continue;
+      return cloneElement(element, {
+        rank: result.rank,
+        highlight: result.highlight,
+        result: result.document,
+        // Use props in situations where a consumer is manually rendering the extension
+        ...element.props,
+      });
+    }
+    return null;
+  },
+};
+
+/**
+ * Terminal fallback strategy: always renders the built-in list item so the
+ * resolver is total.
+ */
+const matchByDefaultListItem: SearchResultListItemMatchStrategy = {
+  name: 'default-list-item',
+  match: (_elements, result) => (
+    <SearchResultListItemExtension rank={result.rank} result={result.document}>
+      <DefaultResultListItem
+        rank={result.rank}
+        highlight={result.highlight}
+        result={result.document}
+      />
+    </SearchResultListItemExtension>
+  ),
+};
+
+/**
+ * Ordered registry of matching strategies. Order encodes resolution
+ * precedence: try predicate-bearing extensions first, then fall back to
+ * the built-in list item. New strategies can be inserted here without
+ * touching the resolver or its callers.
+ */
+const searchResultListItemMatchStrategies: SearchResultListItemMatchStrategy[] =
+  [matchByRegisteredPredicate, matchByDefaultListItem];
+
+/**
+ * @internal
+ * Walks the strategy registry in order and returns the first non-null
+ * element produced. Always returns an element because the
+ * default-list-item strategy is unconditional.
+ */
+const resolveSearchResultListItemElement = (
+  elements: ReactNode[],
+  result: SearchResult,
+): ReactElement => {
+  for (const strategy of searchResultListItemMatchStrategies) {
+    const matched = strategy.match(elements, result);
+    if (matched) return matched;
+  }
+  // Unreachable: the default-list-item strategy is unconditional.
+  throw new Error(
+    'No search result list item match strategy produced an element',
+  );
+};
+
+/**
  * @public
  * Returns a function that renders a result using extensions.
  */
@@ -200,29 +261,11 @@ export const useSearchResultListItemExtensions = (children: ReactNode) => {
   );
 
   return useCallback(
-    (result: SearchResult, key?: number) => {
-      const element = findSearchResultListItemExtensionElement(
-        elements,
-        result,
-      );
-
-      return (
-        <Fragment key={key}>
-          {element ?? (
-            <SearchResultListItemExtension
-              rank={result.rank}
-              result={result.document}
-            >
-              <DefaultResultListItem
-                rank={result.rank}
-                highlight={result.highlight}
-                result={result.document}
-              />
-            </SearchResultListItemExtension>
-          )}
-        </Fragment>
-      );
-    },
+    (result: SearchResult, key?: number) => (
+      <Fragment key={key}>
+        {resolveSearchResultListItemElement(elements, result)}
+      </Fragment>
+    ),
     [elements],
   );
 };


### PR DESCRIPTION
Closes #53

## Summary

- **Problem:** `useSearchResultListItemExtensions` and its helper `findSearchResultListItemExtensionElement` mixed several concerns inside one for-loop: validity filtering, predicate lookup via `getComponentData`, fallback to the built-in list item, and prop merging on the matched extension. Adding new matching rules meant editing this monolith and risking regressions in existing extension behavior.
- **Approach:** Extracted matching into explicit, named **Strategy** units stored in an ordered registry. The resolver walks the registry and returns the first non-null match. Resolution precedence is now data (the registry array), not control flow.
- **Behavior:** Unchanged. Same predicate-match cloning (with `...element.props` override), same default fallback, same hook signature.

## Design pattern

- **Pattern:** Strategy (Behavioral), composed via an ordered registry.
- **Rationale:** Different matching rules are interchangeable algorithms with the same signature `(elements, result) => ReactElement | null`. A registry of strategies makes precedence explicit and lets each rule be added, removed, reordered, or tested in isolation.

### Before / after responsibility map

- **Before:**
  - `findSearchResultListItemExtensionElement` owned: validity filtering, predicate lookup, prop merging, and abstaining via `null`.
  - `useSearchResultListItemExtensions` owned: dispatch + the implicit `?? <DefaultResultListItem />` fallback.
- **After:**
  - `matchByRegisteredPredicate` owns: predicate-based selection + cloning of the matched extension.
  - `matchByDefaultListItem` owns: the unconditional fallback that guarantees totality.
  - `searchResultListItemMatchStrategies` owns: precedence (just an array order).
  - `resolveSearchResultListItemElement` owns: dispatch (walk + first-non-null).
  - `useSearchResultListItemExtensions` only orchestrates filtering of children and calls the resolver.

## Files changed

- `plugins/search-react/src/extensions.tsx`
  - Removed the ad hoc `findSearchResultListItemExtensionElement` and the inline fallback inside the hook.
  - Introduced `SearchResultListItemMatchStrategy`, `matchByRegisteredPredicate`, `matchByDefaultListItem`, `searchResultListItemMatchStrategies`, and `resolveSearchResultListItemElement`.
  - `useSearchResultListItemExtensions` now delegates entirely to the resolver.
- `plugins/search-react/src/extensions.test.tsx`
  - Added two strategy-focused tests:
    - **Fallback path:** an `Explore`-only predicate extension; non-matching results hit the default-list-item strategy.
    - **Precedence:** two extensions with identical predicates; only the first registered renders.

## Verification

- `yarn workspace @backstage/plugin-search-react lint` — clean.
- `yarn workspace @backstage/plugin-search-react test --testPathPatterns extensions` — **7/7** pass (5 existing + 2 new).
- `yarn workspace @backstage/plugin-search-react test` — **17/18 suites green, 129/133 tests pass.** The 4 failures are in `SearchFilter/hooks.test.tsx` (`useAsyncFilterValues`) and are **pre-existing on the base branch**, unrelated to this PR. Verified via `git stash`-and-rerun.
  - Specifically, all consumers of the matching pipeline pass:
    - `extensions.test.tsx` (5 existing + 2 new)
    - `SearchResult.test.tsx`, `SearchResultList.test.tsx`, `SearchResultGroup.test.tsx`
    - `alpha/blueprints/SearchResultListItemBlueprint.test.tsx`

## Evidence of improvement

- **Single point of precedence:** Resolution order lives in `searchResultListItemMatchStrategies` (one line). Adding a new rule = add one strategy and place it in the registry. No edits to dispatch logic.
- **Smaller surface per unit:** Each strategy has one job. The validity filter + predicate lookup remains in one place (`matchByRegisteredPredicate`); the fallback is its own labelled unit.
- **Explicit contracts:** Strategies share the type `(elements, result) => ReactElement | null`, with `null` meaning "abstain". The default-list-item strategy is documented as unconditional, making the resolver total.
- **Improved testability:** New tests directly exercise (1) the fallback path and (2) precedence, which were previously implicit. Future strategies can each get focused tests without re-rendering the whole list pipeline.

## Non-goals

- No new extension APIs (`createSearchResultListItemExtension`, predicate semantics, and `SearchResultListItemExtensionsProps` are unchanged).
- No redesign of rendered result components.
- No performance optimization beyond structural cleanup.
- No public API surface changes; new types/strategies are package-internal (`@internal`). `report.api.md` not touched.

## Reviewer checklist

- [ ] `useSearchResultListItemExtensions` dispatches through `resolveSearchResultListItemElement`; no more inline `if (loading)`-style branching or `?? <DefaultResultListItem />` fallback.
- [ ] `matchByRegisteredPredicate` preserves the previous cloning shape: `rank`, `highlight`, `result.document`, then `...element.props` (so consumer-provided props still win, matching prior behavior).
- [ ] `matchByDefaultListItem` reproduces the original `<SearchResultListItemExtension>{<DefaultResultListItem />}</SearchResultListItemExtension>` shape with the same props.
- [ ] Registry order encodes precedence; predicate-match strategy is first, default-list-item strategy is last.
- [ ] `<Fragment key=…>` wrapping is preserved in the hook output.
- [ ] No public API surface change (`createSearchResultListItemExtension`, the predicate option, hook signature, props types unchanged).
- [ ] New tests cover (a) fallback path when no predicate matches and (b) first-match-wins precedence between competing predicates.
- [ ] `yarn workspace @backstage/plugin-search-react lint` passes.
- [ ] `yarn workspace @backstage/plugin-search-react test --testPathPatterns extensions` passes (7/7).
- [ ] No regressions in dependent suites (`SearchResult*`, `SearchResultListItemBlueprint`).
- [ ] Pre-existing `SearchFilter/hooks.test.tsx` failures are confirmed pre-existing (visible on `main`/base branch) and unrelated to this PR.