### PR TITLE
630:P3 Code Duplication in SearchFilter option resolution -> refactor toward Template Method

### DIFF
--- a/plugins/search-react/src/components/SearchFilter/SearchFilter.Autocomplete.tsx
+++ b/plugins/search-react/src/components/SearchFilter/SearchFilter.Autocomplete.tsx
@@ -23,7 +23,7 @@ import Autocomplete, {
 } from '@material-ui/lab/Autocomplete';
 
 import { useSearch } from '../../context';
-import { useAsyncFilterValues, useDefaultFilterValue } from './hooks';
+import { useResolvedFilterValues } from './hooks';
 import { SearchFilterComponentProps } from './SearchFilter';
 import { ensureFilterValueWithLabel, FilterValueWithLabel } from './types';
 
@@ -52,19 +52,13 @@ export const AutocompleteFilter = (props: SearchAutocompleteFilterProps) => {
     multiple,
   } = props;
   const [inputValue, setInputValue] = useState<string>('');
-  useDefaultFilterValue(name, defaultValue);
-  const asyncValues =
-    typeof givenValues === 'function' ? givenValues : undefined;
-  const defaultValues =
-    typeof givenValues === 'function'
-      ? undefined
-      : givenValues?.map(v => ensureFilterValueWithLabel(v));
-  const { value: values, loading } = useAsyncFilterValues(
-    asyncValues,
+  const { value: values, loading } = useResolvedFilterValues({
+    name,
+    values: givenValues,
+    defaultValue,
     inputValue,
-    defaultValues,
     valuesDebounceMs,
-  );
+  });
   const { filters, setFilters } = useSearch();
   const filterValueWithLabel = ensureFilterValueWithLabel(
     filters[name] as string | string[] | undefined,

--- a/plugins/search-react/src/components/SearchFilter/SearchFilter.tsx
+++ b/plugins/search-react/src/components/SearchFilter/SearchFilter.tsx
@@ -29,8 +29,8 @@ import {
   AutocompleteFilter,
   SearchAutocompleteFilterProps,
 } from './SearchFilter.Autocomplete';
-import { useAsyncFilterValues, useDefaultFilterValue } from './hooks';
-import { ensureFilterValueWithLabel, FilterValue } from './types';
+import { useResolvedFilterValues } from './hooks';
+import { FilterValue } from './types';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { searchReactTranslationRef } from '../../translation';
 
@@ -94,19 +94,13 @@ export const CheckboxFilter = (props: SearchFilterComponentProps) => {
   } = props;
   const classes = useStyles();
   const { filters, setFilters } = useSearch();
-  useDefaultFilterValue(name, defaultValue);
-  const asyncValues =
-    typeof givenValues === 'function' ? givenValues : undefined;
-  const defaultValues =
-    typeof givenValues === 'function'
-      ? undefined
-      : givenValues.map(v => ensureFilterValueWithLabel(v));
-  const { value: values = [], loading } = useAsyncFilterValues(
-    asyncValues,
-    '',
-    defaultValues,
+  const { value: values = [], loading } = useResolvedFilterValues({
+    name,
+    values: givenValues,
+    defaultValue,
+    inputValue: '',
     valuesDebounceMs,
-  );
+  });
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const {
@@ -168,19 +162,13 @@ export const SelectFilter = (props: SearchFilterComponentProps) => {
     valuesDebounceMs,
   } = props;
   const { t } = useTranslationRef(searchReactTranslationRef);
-  useDefaultFilterValue(name, defaultValue);
-  const asyncValues =
-    typeof givenValues === 'function' ? givenValues : undefined;
-  const defaultValues =
-    typeof givenValues === 'function'
-      ? undefined
-      : givenValues?.map(v => ensureFilterValueWithLabel(v));
-  const { value: values = [], loading } = useAsyncFilterValues(
-    asyncValues,
-    '',
-    defaultValues,
+  const { value: values = [], loading } = useResolvedFilterValues({
+    name,
+    values: givenValues,
+    defaultValue,
+    inputValue: '',
     valuesDebounceMs,
-  );
+  });
   const allOptionValue = useRef(uuid());
   const allOption = {
     value: allOptionValue.current,

--- a/plugins/search-react/src/components/SearchFilter/hooks.ts
+++ b/plugins/search-react/src/components/SearchFilter/hooks.ts
@@ -91,6 +91,46 @@ export const useAsyncFilterValues = (
 };
 
 /**
+ * Shared workflow hook used by search filter controls.
+ *
+ * Applies a default filter value in search context, then resolves option values
+ * from either a static list or an async provider.
+ *
+ * @public
+ */
+export const useResolvedFilterValues = (options: {
+  name: string;
+  values?: FilterValue[] | ((partial: string) => Promise<FilterValue[]>);
+  defaultValue?: string | string[] | null;
+  inputValue?: string;
+  valuesDebounceMs?: number;
+}) => {
+  const {
+    name,
+    values: givenValues,
+    defaultValue,
+    inputValue = '',
+    valuesDebounceMs,
+  } = options;
+
+  useDefaultFilterValue(name, defaultValue);
+
+  const asyncValues =
+    typeof givenValues === 'function' ? givenValues : undefined;
+  const defaultValues =
+    typeof givenValues === 'function'
+      ? undefined
+      : givenValues?.map(v => ensureFilterValueWithLabel(v));
+
+  return useAsyncFilterValues(
+    asyncValues,
+    inputValue,
+    defaultValues,
+    valuesDebounceMs,
+  );
+};
+
+/**
  * Utility hook for applying a given default value to the search context.
  *
  * @public


### PR DESCRIPTION
## Summary
- Add a shared `useResolvedFilterValues` hook to centralize default filter setup and option-resolution flow.
- Update `CheckboxFilter`, `SelectFilter`, and `AutocompleteFilter` to use the shared hook instead of duplicating setup logic.
- Keep existing filter rendering and selection behavior unchanged while reducing maintenance duplication.

Closes #46

## Test plan
- [x] `yarn test --no-watch plugins/search-react/src/components/SearchFilter/SearchFilter.test.tsx plugins/search-react/src/components/SearchFilter/SearchFilter.Autocomplete.test.tsx`