### PR TITLE
630:P3 Shotgun Surgery risk in action lookup flow -> centralize with Strategy

### DIFF
--- a/plugins/mcp-actions-backend/src/services/McpService.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.ts
@@ -25,16 +25,23 @@ import { version } from '@backstage/plugin-mcp-actions-backend/package.json';
 import { NotFoundError } from '@backstage/errors';
 
 import { handleErrors } from './handleErrors';
+import {
+  type ActionResolutionStrategy,
+  createActionResolutionStrategy,
+} from './actionResolutionStrategy';
 
 type CallToolParams = { name: string; arguments?: Record<string, unknown> };
 
 async function invokeRegisteredAction(
-  actions: ActionsService,
-  credentials: BackstageCredentials,
-  params: CallToolParams,
+  deps: {
+    actions: ActionsService;
+    strategy: ActionResolutionStrategy;
+    credentials: BackstageCredentials;
+    params: CallToolParams;
+  },
 ) {
-  const { actions: listed } = await actions.list({ credentials });
-  const action = listed.find(a => a.name === params.name);
+  const { actions, strategy, credentials, params } = deps;
+  const action = await strategy.findActionByName(params.name);
 
   if (!action) {
     throw new NotFoundError(`Action "${params.name}" not found`);
@@ -67,26 +74,12 @@ export function createListToolsHandler(deps: {
   credentials: BackstageCredentials;
 }) {
   const { actions, credentials } = deps;
+  const strategy = createActionResolutionStrategy({ actions, credentials });
+
   return async () => {
     // TODO: switch this to be configuration based later
-    const { actions: listed } = await actions.list({ credentials });
-
     return {
-      tools: listed.map(action => ({
-        inputSchema: action.schema.input,
-        // todo(blam): this is unfortunately not supported by most clients yet.
-        // When this is provided you need to provide structuredContent instead.
-        // outputSchema: action.schema.output,
-        name: action.name,
-        description: action.description,
-        annotations: {
-          title: action.title,
-          destructiveHint: action.attributes.destructive,
-          idempotentHint: action.attributes.idempotent,
-          readOnlyHint: action.attributes.readOnly,
-          openWorldHint: false,
-        },
-      })),
+      tools: await strategy.listTools(),
     };
   };
 }
@@ -99,9 +92,16 @@ export function createCallToolHandler(deps: {
   credentials: BackstageCredentials;
 }) {
   const { actions, credentials } = deps;
+  const strategy = createActionResolutionStrategy({ actions, credentials });
+
   return async ({ params }: { params: CallToolParams }) => {
     return handleErrors(async () =>
-      invokeRegisteredAction(actions, credentials, params),
+      invokeRegisteredAction({
+        actions,
+        strategy,
+        credentials,
+        params,
+      }),
     );
   };
 }

--- a/plugins/mcp-actions-backend/src/services/actionResolutionStrategy.test.ts
+++ b/plugins/mcp-actions-backend/src/services/actionResolutionStrategy.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockCredentials } from '@backstage/backend-test-utils';
+import { actionsRegistryServiceMock } from '@backstage/backend-test-utils/alpha';
+import { expectedMcpTool } from '../testUtils/expectedMcpTool';
+import { createActionResolutionStrategy } from './actionResolutionStrategy';
+
+describe('actionResolutionStrategy', () => {
+  function createMockActionsRegistry() {
+    const actions = actionsRegistryServiceMock();
+    actions.register({
+      name: 'mock-action',
+      title: 'Test',
+      description: 'Test',
+      schema: {
+        input: z => z.object({ input: z.string() }),
+        output: z => z.object({ output: z.string() }),
+      },
+      action: async () => ({ output: { output: 'test' } }),
+    });
+    return actions;
+  }
+
+  it('maps registered actions to MCP tools', async () => {
+    const actions = createMockActionsRegistry();
+    const strategy = createActionResolutionStrategy({
+      actions,
+      credentials: mockCredentials.user(),
+    });
+
+    const tools = await strategy.listTools();
+
+    expect(tools).toEqual([
+      expectedMcpTool({
+        name: 'mock-action',
+        title: 'Test',
+        description: 'Test',
+        inputProperties: {
+          input: {
+            type: 'string',
+          },
+        },
+        required: ['input'],
+      }),
+    ]);
+  });
+
+  it('finds a registered action by name', async () => {
+    const actions = createMockActionsRegistry();
+    const strategy = createActionResolutionStrategy({
+      actions,
+      credentials: mockCredentials.user(),
+    });
+
+    const action = await strategy.findActionByName('mock-action');
+
+    expect(action).toMatchObject({
+      name: 'mock-action',
+      title: 'Test',
+      description: 'Test',
+    });
+  });
+
+  it('returns undefined when action name is unknown', async () => {
+    const actions = createMockActionsRegistry();
+    const strategy = createActionResolutionStrategy({
+      actions,
+      credentials: mockCredentials.user(),
+    });
+
+    const action = await strategy.findActionByName('does-not-exist');
+
+    expect(action).toBeUndefined();
+  });
+});

--- a/plugins/mcp-actions-backend/src/services/actionResolutionStrategy.ts
+++ b/plugins/mcp-actions-backend/src/services/actionResolutionStrategy.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { BackstageCredentials } from '@backstage/backend-plugin-api';
+import { ActionsService } from '@backstage/backend-plugin-api/alpha';
+
+type RegisteredAction = Awaited<ReturnType<ActionsService['list']>>['actions'][number];
+
+function toMcpTool(action: RegisteredAction) {
+  return {
+    inputSchema: action.schema.input,
+    // todo(blam): this is unfortunately not supported by most clients yet.
+    // When this is provided you need to provide structuredContent instead.
+    // outputSchema: action.schema.output,
+    name: action.name,
+    description: action.description,
+    annotations: {
+      title: action.title,
+      destructiveHint: action.attributes.destructive,
+      idempotentHint: action.attributes.idempotent,
+      readOnlyHint: action.attributes.readOnly,
+      openWorldHint: false,
+    },
+  };
+}
+
+export type ActionResolutionStrategy = {
+  listTools: () => Promise<ReturnType<typeof toMcpTool>[]>;
+  findActionByName: (name: string) => Promise<RegisteredAction | undefined>;
+};
+
+export function createActionResolutionStrategy(deps: {
+  actions: ActionsService;
+  credentials: BackstageCredentials;
+}): ActionResolutionStrategy {
+  const { actions, credentials } = deps;
+
+  const listRegisteredActions = async (): Promise<RegisteredAction[]> => {
+    const { actions: listed } = await actions.list({ credentials });
+    return listed;
+  };
+
+  return {
+    async listTools() {
+      const listed = await listRegisteredActions();
+      return listed.map(action => toMcpTool(action));
+    },
+    async findActionByName(name: string) {
+      const listed = await listRegisteredActions();
+      return listed.find(action => action.name === name);
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Introduce `actionResolutionStrategy` to centralize action-to-tool mapping and name-based action lookup in one policy module.
- Update `createListToolsHandler` and `createCallToolHandler` to use the shared strategy, keeping transport concerns separate from lookup policy.
- Add strategy-focused unit tests to lock in lookup consistency and unchanged behavior.

Closes #52

## Test plan
- [x] `yarn test --no-watch plugins/mcp-actions-backend/src/services/actionResolutionStrategy.test.ts plugins/mcp-actions-backend/src/services/McpService.test.ts`
- [x] `yarn test --no-watch plugins/mcp-actions-backend/src/plugin.test.ts`