### PR TITLE
630:P3 Global State Overuse in default filter initialization -> stabilize with State

### DIFF
--- a/plugins/search-react/src/components/SearchFilter/SearchFilter.Autocomplete.tsx
+++ b/plugins/search-react/src/components/SearchFilter/SearchFilter.Autocomplete.tsx
@@ -23,7 +23,7 @@ import Autocomplete, {
 } from '@material-ui/lab/Autocomplete';
 
 import { useSearch } from '../../context';
-import { useAsyncFilterValues, useDefaultFilterValue } from './hooks';
+import { useAsyncFilterValues } from './hooks';
 import { SearchFilterComponentProps } from './SearchFilter';
 import { ensureFilterValueWithLabel, FilterValueWithLabel } from './types';
 
@@ -42,7 +42,6 @@ export type SearchAutocompleteFilterProps = SearchFilterComponentProps & {
 export const AutocompleteFilter = (props: SearchAutocompleteFilterProps) => {
   const {
     className,
-    defaultValue,
     name,
     values: givenValues,
     valuesDebounceMs,
@@ -52,7 +51,6 @@ export const AutocompleteFilter = (props: SearchAutocompleteFilterProps) => {
     multiple,
   } = props;
   const [inputValue, setInputValue] = useState<string>('');
-  useDefaultFilterValue(name, defaultValue);
   const asyncValues =
     typeof givenValues === 'function' ? givenValues : undefined;
   const defaultValues =

--- a/plugins/search-react/src/components/SearchFilter/SearchFilter.test.tsx
+++ b/plugins/search-react/src/components/SearchFilter/SearchFilter.test.tsx
@@ -60,7 +60,16 @@ describe('SearchFilter', () => {
     const CustomFilter = (props: { name: string }) => <h6>{props.name}</h6>;
 
     await renderInTestApp(
-      <SearchFilter name={name} component={CustomFilter} />,
+      <TestApiProvider
+        apis={[
+          [searchApiRef, searchApiMock],
+          [configApiRef, configApiMock],
+        ]}
+      >
+        <SearchContextProvider initialState={initialState}>
+          <SearchFilter name={name} component={CustomFilter} />
+        </SearchContextProvider>
+      </TestApiProvider>,
     );
 
     expect(screen.getByRole('heading', { name })).toBeInTheDocument();

--- a/plugins/search-react/src/components/SearchFilter/SearchFilter.tsx
+++ b/plugins/search-react/src/components/SearchFilter/SearchFilter.tsx
@@ -86,7 +86,6 @@ export type SearchFilterWrapperProps = SearchFilterComponentProps & {
 export const CheckboxFilter = (props: SearchFilterComponentProps) => {
   const {
     className,
-    defaultValue,
     label: formLabel,
     name,
     values: givenValues = [],
@@ -94,7 +93,6 @@ export const CheckboxFilter = (props: SearchFilterComponentProps) => {
   } = props;
   const classes = useStyles();
   const { filters, setFilters } = useSearch();
-  useDefaultFilterValue(name, defaultValue);
   const asyncValues =
     typeof givenValues === 'function' ? givenValues : undefined;
   const defaultValues =
@@ -161,14 +159,12 @@ export const CheckboxFilter = (props: SearchFilterComponentProps) => {
 export const SelectFilter = (props: SearchFilterComponentProps) => {
   const {
     className,
-    defaultValue,
     label,
     name,
     values: givenValues,
     valuesDebounceMs,
   } = props;
   const { t } = useTranslationRef(searchReactTranslationRef);
-  useDefaultFilterValue(name, defaultValue);
   const asyncValues =
     typeof givenValues === 'function' ? givenValues : undefined;
   const defaultValues =
@@ -222,6 +218,7 @@ export const SelectFilter = (props: SearchFilterComponentProps) => {
  */
 const SearchFilter = (props: SearchFilterWrapperProps) => {
   const { component: Element, ...elementProps } = props;
+  useDefaultFilterValue(elementProps.name, elementProps.defaultValue);
   return <Element {...elementProps} />;
 };
 

--- a/plugins/search-react/src/components/SearchFilter/hooks.test.tsx
+++ b/plugins/search-react/src/components/SearchFilter/hooks.test.tsx
@@ -20,7 +20,11 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 
 import { searchApiRef } from '../../api';
 import { SearchContextProvider, useSearch } from '../../context';
-import { useDefaultFilterValue, useAsyncFilterValues } from './hooks';
+import {
+  resolveDefaultFilterInitializationState,
+  useDefaultFilterValue,
+  useAsyncFilterValues,
+} from './hooks';
 import { configApiRef } from '@backstage/core-plugin-api';
 
 jest.useFakeTimers();
@@ -104,6 +108,33 @@ describe('SearchFilter.hooks', () => {
 
       await waitFor(() => {
         expect(result.current.filters[expectedFilter]).toEqual(expectedValue);
+      });
+    });
+
+    it('should not overwrite an existing filter with default value', async () => {
+      const expectedFilter = 'someField';
+      const existingValue = 'existingValue';
+      const defaultValue = 'defaultValue';
+      const { result } = renderHook(
+        () => {
+          useDefaultFilterValue(expectedFilter, defaultValue);
+          return useSearch();
+        },
+        {
+          wrapper: ({ children }) =>
+            wrapper({
+              children,
+              overrides: {
+                filters: {
+                  [expectedFilter]: existingValue,
+                },
+              },
+            }),
+        },
+      );
+
+      await waitFor(() => {
+        expect(result.current.filters[expectedFilter]).toEqual(existingValue);
       });
     });
 
@@ -235,6 +266,29 @@ describe('SearchFilter.hooks', () => {
       await waitFor(() => {
         expect(result.current.filters.unrelatedField).toEqual('unrelatedValue');
       });
+    });
+  });
+
+  describe('resolveDefaultFilterInitializationState', () => {
+    it('transitions pending state to applied', () => {
+      expect(resolveDefaultFilterInitializationState('pending', 'apply')).toBe(
+        'applied',
+      );
+    });
+
+    it('transitions pending state to skipped', () => {
+      expect(resolveDefaultFilterInitializationState('pending', 'skip')).toBe(
+        'skipped',
+      );
+    });
+
+    it('does not transition from terminal states', () => {
+      expect(resolveDefaultFilterInitializationState('applied', 'skip')).toBe(
+        'applied',
+      );
+      expect(resolveDefaultFilterInitializationState('skipped', 'apply')).toBe(
+        'skipped',
+      );
     });
   });
 

--- a/plugins/search-react/src/components/SearchFilter/hooks.ts
+++ b/plugins/search-react/src/components/SearchFilter/hooks.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useReducer, useRef } from 'react';
 import useAsyncFn from 'react-use/esm/useAsyncFn';
 import useDebounce from 'react-use/esm/useDebounce';
 
@@ -24,6 +24,36 @@ import {
   FilterValue,
   FilterValueWithLabel,
 } from './types';
+
+export type DefaultFilterInitializationState = 'pending' | 'applied' | 'skipped';
+
+type DefaultFilterInitializationEvent = 'apply' | 'skip';
+
+export function resolveDefaultFilterInitializationState(
+  state: DefaultFilterInitializationState,
+  event: DefaultFilterInitializationEvent,
+): DefaultFilterInitializationState {
+  if (state !== 'pending') {
+    return state;
+  }
+
+  return event === 'apply' ? 'applied' : 'skipped';
+}
+
+function normalizeDefaultFilterValue(
+  defaultValue?: string | string[] | null,
+): string | string[] | undefined {
+  if (defaultValue === undefined || defaultValue === null) {
+    return undefined;
+  }
+
+  if (Array.isArray(defaultValue)) {
+    const normalized = defaultValue.filter(value => value.length > 0);
+    return normalized.length > 0 ? normalized : undefined;
+  }
+
+  return defaultValue.length > 0 ? defaultValue : undefined;
+}
 
 /**
  * Utility hook for either asynchronously loading filter values from a given
@@ -100,14 +130,29 @@ export const useDefaultFilterValue = (
   defaultValue?: string | string[] | null,
 ) => {
   const { setFilters } = useSearch();
+  const [initializationState, setInitializationState] = useReducer(
+    resolveDefaultFilterInitializationState,
+    'pending',
+  );
 
   useEffect(() => {
-    if (defaultValue && [defaultValue].flat().length > 0) {
-      setFilters(prevFilters => ({
-        ...prevFilters,
-        [name]: defaultValue,
-      }));
+    if (initializationState !== 'pending') {
+      return;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+
+    const normalizedDefaultValue = normalizeDefaultFilterValue(defaultValue);
+
+    if (normalizedDefaultValue === undefined) {
+      setInitializationState('skip');
+      return;
+    }
+
+    setFilters(prevFilters =>
+      prevFilters[name] === undefined
+        ? { ...prevFilters, [name]: normalizedDefaultValue }
+        : prevFilters,
+    );
+
+    setInitializationState('apply');
+  }, [defaultValue, initializationState, name, setFilters]);
 };


### PR DESCRIPTION
## Summary
- Centralize default filter initialization in one wrapper-driven flow (`SearchFilter`) instead of repeating initialization hooks across each filter variant.
- Introduce explicit default-initialization state transitions in `hooks.ts` (`pending -> applied/skipped`) to make initialization behavior deterministic.
- Preserve existing default-value behavior while preventing defaults from overwriting already-initialized filter state, and add targeted test coverage.

Closes #48

## Test plan
- [x] `yarn test --no-watch plugins/search-react/src/components/SearchFilter/SearchFilter.test.tsx plugins/search-react/src/components/SearchFilter/SearchFilter.Autocomplete.test.tsx`
- [x] `yarn test --no-watch plugins/search-react/src/components/SearchFilter/hooks.test.tsx --testNamePattern "useDefaultFilterValue|resolveDefaultFilterInitializationState"`